### PR TITLE
Update OpenTelemetry semantic conventions and add Pino instrumentation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,7 +28,6 @@
     "@opentelemetry/exporter-logs-otlp-http": "0.213.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.213.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.213.0",
-    "@opentelemetry/instrumentation-http": "0.213.0",
     "@opentelemetry/instrumentation-ioredis": "0.61.0",
     "@opentelemetry/instrumentation-pg": "0.65.0",
     "@opentelemetry/instrumentation-pino": "0.59.0",

--- a/apps/api/src/instrumentation.ts
+++ b/apps/api/src/instrumentation.ts
@@ -3,6 +3,7 @@ import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { IORedisInstrumentation } from "@opentelemetry/instrumentation-ioredis";
 import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
+import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
@@ -27,6 +28,7 @@ const sdk = new NodeSDK({
   instrumentations: [
     new PgInstrumentation({ enhancedDatabaseReporting: true }),
     new IORedisInstrumentation(),
+    new PinoInstrumentation(),
   ],
 });
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,6 @@
     "@opentelemetry/exporter-logs-otlp-http": "0.213.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.213.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.213.0",
-    "@opentelemetry/instrumentation-http": "0.213.0",
     "@opentelemetry/instrumentation-pino": "0.59.0",
     "@opentelemetry/instrumentation-undici": "^0.23.0",
     "@opentelemetry/resources": "2.6.0",

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,6 +1,7 @@
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
 import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
@@ -23,7 +24,7 @@ const sdk = new NodeSDK({
   metricReader: new PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter({ url: `${otlpEndpoint}/v1/metrics` }),
   }),
-  instrumentations: [new UndiciInstrumentation()],
+  instrumentations: [new UndiciInstrumentation(), new PinoInstrumentation()],
 });
 
 sdk.start();

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -9,14 +9,17 @@ const tracingMiddleware = createMiddleware({ type: "request" }).server(
       `${request.method} ${pathname}`,
       async (span) => {
         span.setAttributes({
-          "http.method": request.method,
-          "http.url": request.url,
+          "http.request.method": request.method,
+          "url.full": request.url,
           "http.route": pathname,
         });
 
         try {
           const result = await next();
-          span.setAttribute("http.status_code", result.response?.status ?? 200);
+          span.setAttribute(
+            "http.response.status_code",
+            result.response?.status ?? 200,
+          );
           span.setStatus({ code: SpanStatusCode.OK });
           return result;
         } catch (error) {


### PR DESCRIPTION
## Summary
This PR updates the OpenTelemetry instrumentation to use the latest semantic conventions for HTTP attributes and adds Pino logging instrumentation to both the web and API applications.

## Key Changes
- **Updated HTTP semantic conventions** in `apps/web/src/start.ts`:
  - Changed `http.method` → `http.request.method`
  - Changed `http.url` → `url.full`
  - Changed `http.status_code` → `http.response.status_code`
  - These changes align with the latest OpenTelemetry semantic conventions specification

- **Added Pino instrumentation** to both applications:
  - Added `PinoInstrumentation` to `apps/web/src/instrumentation.ts`
  - Added `PinoInstrumentation` to `apps/api/src/instrumentation.ts`
  - Enables automatic tracing and logging correlation for Pino logger instances

- **Removed unused HTTP instrumentation dependency**:
  - Removed `@opentelemetry/instrumentation-http` from both `apps/api/package.json` and `apps/web/package.json`
  - This dependency is no longer needed as custom HTTP tracing is implemented via middleware

## Implementation Details
The semantic convention updates ensure compatibility with the latest OpenTelemetry standards for HTTP span attributes. The addition of Pino instrumentation provides automatic context propagation and correlation between logs and traces across both applications.

https://claude.ai/code/session_01SnUJnZe8YAZiWJG4ZzMvMf