### PR TITLE
fix(otel): remove duplicate log emission and fix span edge cases

### DIFF
--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -16,14 +16,16 @@ const tracingMiddleware = createMiddleware({ type: "request" }).server(
 
         try {
           const result = await next();
-          span.setAttribute(
-            "http.response.status_code",
-            result.response?.status ?? 200,
-          );
+          if (result.response?.status != null) {
+            span.setAttribute(
+              "http.response.status_code",
+              result.response.status,
+            );
+          }
           span.setStatus({ code: SpanStatusCode.OK });
           return result;
         } catch (error) {
-          span.recordException(error as Error);
+          span.recordException(error as Error | string);
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: error instanceof Error ? error.message : String(error),

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -10,12 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.213.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.0.0"
-  },
-  "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <2.0.0"
   },
   "devDependencies": {
     "@kubeasy/typescript-config": "workspace:*",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,4 +1,3 @@
-import { logs, SeverityNumber } from "@opentelemetry/api-logs";
 import pino from "pino";
 import PinoPretty from "pino-pretty";
 
@@ -11,59 +10,31 @@ const level = process.env.LOG_LEVEL ?? (isDev ? "debug" : "info");
 
 // In dev, use pino-pretty as a sync stream (not a worker transport) so that
 // the main thread is not blocked and OTel can emit in the same context.
+// PinoInstrumentation (registered in instrumentation.ts) intercepts pino calls
+// and emits OTel log records automatically, including trace_id/span_id correlation.
 const pinoInstance = isDev
   ? pino({ level }, PinoPretty({ colorize: true, sync: true }))
   : pino({ level });
-
-const otelLogger = logs.getLogger("kubeasy");
-
-const SEVERITY: Record<string, SeverityNumber> = {
-  debug: SeverityNumber.DEBUG,
-  info: SeverityNumber.INFO,
-  warn: SeverityNumber.WARN,
-  error: SeverityNumber.ERROR,
-};
-
-function emit(
-  severityText: "debug" | "info" | "warn" | "error",
-  message: string,
-  attributes?: LogAttributes,
-) {
-  try {
-    otelLogger.emit({
-      severityNumber: SEVERITY[severityText],
-      severityText: severityText.toUpperCase(),
-      body: message,
-      attributes,
-    });
-  } catch {
-    // OTel not initialised (e.g. tests) — silently ignore
-  }
-}
 
 export const logger = {
   debug: (message: string, attributes?: LogAttributes) => {
     attributes
       ? pinoInstance.debug(attributes, message)
       : pinoInstance.debug(message);
-    emit("debug", message, attributes);
   },
   info: (message: string, attributes?: LogAttributes) => {
     attributes
       ? pinoInstance.info(attributes, message)
       : pinoInstance.info(message);
-    emit("info", message, attributes);
   },
   warn: (message: string, attributes?: LogAttributes) => {
     attributes
       ? pinoInstance.warn(attributes, message)
       : pinoInstance.warn(message);
-    emit("warn", message, attributes);
   },
   error: (message: string, attributes?: LogAttributes) => {
     attributes
       ? pinoInstance.error(attributes, message)
       : pinoInstance.error(message);
-    emit("error", message, attributes);
   },
 };


### PR DESCRIPTION
- Remove manual otelLogger.emit() from packages/logger: PinoInstrumentation already intercepts pino calls and emits OTel records with trace_id/span_id correlation — the manual emit caused every log to appear twice in the backend
- Drop @opentelemetry/api-logs dependency from @kubeasy/logger (no longer used)
- Fix misleading http.response.status_code default: only set the attribute when result.response?.status is non-null instead of defaulting to 200
- Fix unsafe Error cast in recordException: use `Error | string` to match the OTel Exception type without narrowing away valid thrown values
