### PR TITLE
fix(web): add recharts to ssr.noExternal to fix Railway healthcheck crash

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -50,6 +50,9 @@ export default defineConfig(async () => {
     resolve: {
       alias: { "@": new URL("./src", import.meta.url).pathname },
     },
+    ssr: {
+      noExternal: ["recharts"],
+    },
     plugins: [
       tanstackStart({
         server: { entry: "./src/server.tsx" },


### PR DESCRIPTION
## Summary

- `recharts` (and its d3 sub-dependencies) are CommonJS modules
- During Nitro SSR, Vite's `__toESM` wrapper returned `undefined` for the default export, causing a `TypeError: Cannot destructure property '__extends'` crash on every request
- This made the Railway healthcheck fail continuously
- Adding `ssr: { noExternal: ['recharts'] }` to `vite.config.ts` forces Vite to bundle recharts into the SSR output rather than treating it as an external CJS module

## Root cause

The `Combination-D_bYIkv4.mjs` chunk (d3-array internals used by recharts) was being imported as a CJS module at runtime. The `__toESM(...).default` call returned `undefined` because the module's CJS interop was broken in the Nitro SSR context. Setting `noExternal` makes Vite handle the ESM transformation at build time instead.

## Test plan

- [ ] Deploy to Railway and verify the healthcheck passes
- [ ] Confirm the dashboard chart (radar chart) still renders correctly

https://claude.ai/code/session_019fSd4tXDGjvDpawFhxhWfK