### PR TITLE
fix(web): lazy-load recharts client-side to fix SSR/prerender crash

### DIFF
--- a/apps/web/src/components/dashboard-chart-client.tsx
+++ b/apps/web/src/components/dashboard-chart-client.tsx
@@ -1,0 +1,89 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { TrendingUp } from "lucide-react";
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+} from "recharts";
+import { completionOptions, themeListOptions } from "@/lib/query-options";
+
+export function DashboardChartClient() {
+  const { data: completion } = useSuspenseQuery(
+    completionOptions({ splitByTheme: true }),
+  );
+  const { data: themeList } = useSuspenseQuery(themeListOptions());
+
+  const chartData =
+    completion?.byTheme?.map((item) => {
+      const theme = themeList?.find((t) => t.slug === item.themeSlug);
+      return {
+        themeName: theme?.name ?? item.themeSlug,
+        percentageCompleted: item.percentageCompleted,
+      };
+    }) ?? [];
+
+  const bestTheme =
+    completion?.byTheme && completion.byTheme.length > 0
+      ? completion.byTheme.reduce((best, item) =>
+          item.percentageCompleted > best.percentageCompleted ? item : best,
+        )
+      : null;
+
+  const bestThemeName = bestTheme
+    ? (themeList?.find((t) => t.slug === bestTheme.themeSlug)?.name ??
+      bestTheme.themeSlug)
+    : null;
+
+  return (
+    <div className="bg-secondary neo-border-thick neo-shadow p-8">
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-2 bg-primary neo-border-thick neo-shadow rounded-lg">
+          <TrendingUp className="w-5 h-5 text-primary-foreground" />
+        </div>
+        <h2 className="text-2xl font-black">Skills by Themes</h2>
+      </div>
+
+      {chartData.length === 0 ? (
+        <div className="flex items-center justify-center h-40 text-muted-foreground font-bold">
+          Master all themes to become a Kubernetes expert!
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={400}>
+          <RadarChart data={chartData}>
+            <PolarGrid stroke="#000" strokeWidth={2} />
+            <PolarAngleAxis
+              dataKey="themeName"
+              tick={{ fill: "#000", fontWeight: "bold", fontSize: 12 }}
+            />
+            <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} />
+            <Radar
+              name="Completion"
+              dataKey="percentageCompleted"
+              stroke="#6366F1"
+              fill="#6366F1"
+              fillOpacity={0.6}
+              strokeWidth={3}
+            />
+          </RadarChart>
+        </ResponsiveContainer>
+      )}
+
+      <div className="mt-4 p-4 bg-secondary neo-border-thick rounded-xl">
+        {bestThemeName && bestTheme && bestTheme.percentageCompleted > 0 ? (
+          <p className="text-sm font-bold text-center">
+            Your best theme is{" "}
+            <span className="text-primary">{bestThemeName}</span> at{" "}
+            {bestTheme.percentageCompleted}%!
+          </p>
+        ) : (
+          <p className="text-sm font-bold text-center">
+            Master all themes to become a Kubernetes expert!
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard-chart.tsx
+++ b/apps/web/src/components/dashboard-chart.tsx
@@ -1,42 +1,7 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { TrendingUp } from "lucide-react";
-import {
-  PolarAngleAxis,
-  PolarGrid,
-  PolarRadiusAxis,
-  Radar,
-  RadarChart,
-  ResponsiveContainer,
-} from "recharts";
-import { completionOptions, themeListOptions } from "@/lib/query-options";
+import { Suspense, lazy, useEffect, useState, type ComponentType } from "react";
 
-export function DashboardChart() {
-  const { data: completion } = useSuspenseQuery(
-    completionOptions({ splitByTheme: true }),
-  );
-  const { data: themeList } = useSuspenseQuery(themeListOptions());
-
-  const chartData =
-    completion?.byTheme?.map((item) => {
-      const theme = themeList?.find((t) => t.slug === item.themeSlug);
-      return {
-        themeName: theme?.name ?? item.themeSlug,
-        percentageCompleted: item.percentageCompleted,
-      };
-    }) ?? [];
-
-  const bestTheme =
-    completion?.byTheme && completion.byTheme.length > 0
-      ? completion.byTheme.reduce((best, item) =>
-          item.percentageCompleted > best.percentageCompleted ? item : best,
-        )
-      : null;
-
-  const bestThemeName = bestTheme
-    ? (themeList?.find((t) => t.slug === bestTheme.themeSlug)?.name ??
-      bestTheme.themeSlug)
-    : null;
-
+function ChartFallback() {
   return (
     <div className="bg-secondary neo-border-thick neo-shadow p-8">
       <div className="flex items-center gap-3 mb-6">
@@ -45,45 +10,30 @@ export function DashboardChart() {
         </div>
         <h2 className="text-2xl font-black">Skills by Themes</h2>
       </div>
-
-      {chartData.length === 0 ? (
-        <div className="flex items-center justify-center h-40 text-muted-foreground font-bold">
-          Master all themes to become a Kubernetes expert!
-        </div>
-      ) : (
-        <ResponsiveContainer width="100%" height={400}>
-          <RadarChart data={chartData}>
-            <PolarGrid stroke="#000" strokeWidth={2} />
-            <PolarAngleAxis
-              dataKey="themeName"
-              tick={{ fill: "#000", fontWeight: "bold", fontSize: 12 }}
-            />
-            <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} />
-            <Radar
-              name="Completion"
-              dataKey="percentageCompleted"
-              stroke="#6366F1"
-              fill="#6366F1"
-              fillOpacity={0.6}
-              strokeWidth={3}
-            />
-          </RadarChart>
-        </ResponsiveContainer>
-      )}
-
-      <div className="mt-4 p-4 bg-secondary neo-border-thick rounded-xl">
-        {bestThemeName && bestTheme && bestTheme.percentageCompleted > 0 ? (
-          <p className="text-sm font-bold text-center">
-            Your best theme is{" "}
-            <span className="text-primary">{bestThemeName}</span> at{" "}
-            {bestTheme.percentageCompleted}%!
-          </p>
-        ) : (
-          <p className="text-sm font-bold text-center">
-            Master all themes to become a Kubernetes expert!
-          </p>
-        )}
+      <div className="flex items-center justify-center h-40 text-muted-foreground font-bold">
+        Loading chart...
       </div>
     </div>
+  );
+}
+
+// Lazy-loaded only on client to keep recharts out of the SSR bundle.
+// useEffect never runs on the server, so the dynamic import is never
+// triggered during SSR/prerender — eliminating the CJS/ESM interop crash.
+export function DashboardChart() {
+  const [Chart, setChart] = useState<ComponentType | null>(null);
+
+  useEffect(() => {
+    import("./dashboard-chart-client").then((m) => {
+      setChart(() => m.DashboardChartClient);
+    });
+  }, []);
+
+  if (!Chart) return <ChartFallback />;
+
+  return (
+    <Suspense fallback={<ChartFallback />}>
+      <Chart />
+    </Suspense>
   );
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -50,9 +50,6 @@ export default defineConfig(async () => {
     resolve: {
       alias: { "@": new URL("./src", import.meta.url).pathname },
     },
-    ssr: {
-      noExternal: ["recharts"],
-    },
     plugins: [
       tanstackStart({
         server: { entry: "./src/server.tsx" },


### PR DESCRIPTION
recharts and its d3/tslib dependencies cause a CJS/ESM interop crash (TypeError: Cannot destructure property '__extends') when bundled into the Nitro SSR output. The root cause: tslib ends up external to Nitro's bundle and returns undefined at runtime.

Fix: split DashboardChart into a thin SSR-safe wrapper (dashboard-chart.tsx) and an inner client-only component (dashboard-chart-client.tsx). The wrapper uses useEffect + dynamic import so recharts is never imported during SSR — useEffect is a no-op on the server. This removes recharts from the SSR bundle entirely, eliminating the crash.

https://claude.ai/code/session_019fSd4tXDGjvDpawFhxhWfK