### PR TITLE
feat(analytics): add reverse proxy support for PostHog (ui_host)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,7 +2,10 @@
 RESEND_API_KEY=""
 
 # PostHog analytics
+# When using a reverse proxy, set VITE_POSTHOG_HOST to your proxy domain (e.g. https://ph.kubeasy.dev)
+# and VITE_POSTHOG_UI_HOST to the actual PostHog cloud URL (required for toolbar + session recordings)
 VITE_POSTHOG_HOST="https://eu.i.posthog.com"
+VITE_POSTHOG_UI_HOST=""
 VITE_POSTHOG_KEY=""
 
 # Notion (blog content)

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -111,6 +111,9 @@ function RootDocument({ children }: { children: ReactNode }) {
             options={{
               api_host:
                 import.meta.env.VITE_POSTHOG_HOST ?? "https://eu.i.posthog.com",
+              ...(import.meta.env.VITE_POSTHOG_UI_HOST && {
+                ui_host: import.meta.env.VITE_POSTHOG_UI_HOST,
+              }),
               capture_pageview: false,
               capture_pageleave: true,
               loaded: (ph) => {


### PR DESCRIPTION
Add VITE_POSTHOG_UI_HOST env var and pass it as ui_host to PostHogProvider when set. Required by PostHog when routing events through a reverse proxy so that toolbar and session recordings still resolve against the real PostHog cloud domain.

https://claude.ai/code/session_01JRvdfY1v1MH8hCb6KAoTDc