### PR TITLE
perf(api): parallelize independent DB queries and XP job dispatches

### DIFF
--- a/apps/api/src/routes/admin/challenges.ts
+++ b/apps/api/src/routes/admin/challenges.ts
@@ -1,4 +1,5 @@
 import { zValidator } from "@hono/zod-validator";
+import { all } from "better-all";
 import { count, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -53,19 +54,26 @@ adminChallenges.get("/", async (c) => {
 
 // GET /api/admin/challenges/stats — global challenge stats
 adminChallenges.get("/stats", async (c) => {
-  const [submissionStats] = await db
-    .select({
-      totalSubmissions: count(userSubmission.id),
-      successfulSubmissions: sql<number>`SUM(CASE WHEN ${userSubmission.validated} = true THEN 1 ELSE 0 END)`,
-    })
-    .from(userSubmission);
-
-  const [progressStats] = await db
-    .select({
-      totalStarts: sql<number>`COUNT(DISTINCT CASE WHEN ${userProgress.status} != 'not_started' THEN ${userProgress.id} END)`,
-      totalCompletions: sql<number>`COUNT(DISTINCT CASE WHEN ${userProgress.status} = 'completed' THEN ${userProgress.id} END)`,
-    })
-    .from(userProgress);
+  const { submissionRows, progressRows } = await all({
+    async submissionRows() {
+      return db
+        .select({
+          totalSubmissions: count(userSubmission.id),
+          successfulSubmissions: sql<number>`SUM(CASE WHEN ${userSubmission.validated} = true THEN 1 ELSE 0 END)`,
+        })
+        .from(userSubmission);
+    },
+    async progressRows() {
+      return db
+        .select({
+          totalStarts: sql<number>`COUNT(DISTINCT CASE WHEN ${userProgress.status} != 'not_started' THEN ${userProgress.id} END)`,
+          totalCompletions: sql<number>`COUNT(DISTINCT CASE WHEN ${userProgress.status} = 'completed' THEN ${userProgress.id} END)`,
+        })
+        .from(userProgress);
+    },
+  });
+  const [submissionStats] = submissionRows;
+  const [progressStats] = progressRows;
 
   const totalSubs = submissionStats?.totalSubmissions ?? 0;
   const successfulSubs = Number(submissionStats?.successfulSubmissions ?? 0);

--- a/apps/api/src/routes/admin/users.ts
+++ b/apps/api/src/routes/admin/users.ts
@@ -1,3 +1,4 @@
+import { all } from "better-all";
 import { count, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { db } from "../../db";
@@ -11,30 +12,36 @@ adminUsers.get("/", async (c) => {
   const limit = Math.min(100, Math.max(1, Number(c.req.query("limit") ?? 50)));
   const offset = (page - 1) * limit;
 
-  const [{ total }] = await db.select({ total: count(user.id) }).from(user);
-
-  const users = await db
-    .select({
-      id: user.id,
-      name: user.name,
-      email: user.email,
-      image: user.image,
-      role: user.role,
-      createdAt: user.createdAt,
-      banned: user.banned,
-      banReason: user.banReason,
-      totalXp: sql<number>`COALESCE(${userXp.totalXp}, 0)`,
-      completedChallenges: sql<number>`(
+  const { countRows, users } = await all({
+    async countRows() {
+      return db.select({ total: count(user.id) }).from(user);
+    },
+    async users() {
+      return db
+        .select({
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          image: user.image,
+          role: user.role,
+          createdAt: user.createdAt,
+          banned: user.banned,
+          banReason: user.banReason,
+          totalXp: sql<number>`COALESCE(${userXp.totalXp}, 0)`,
+          completedChallenges: sql<number>`(
         SELECT COUNT(*) FROM user_progress
         WHERE user_progress.user_id = ${user.id}
         AND user_progress.status = 'completed'
       )`,
-    })
-    .from(user)
-    .leftJoin(userXp, eq(user.id, userXp.userId))
-    .orderBy(user.createdAt)
-    .limit(limit)
-    .offset(offset);
+        })
+        .from(user)
+        .leftJoin(userXp, eq(user.id, userXp.userId))
+        .orderBy(user.createdAt)
+        .limit(limit)
+        .offset(offset);
+    },
+  });
+  const [{ total }] = countRows;
 
   return c.json({ users, total, page, limit });
 });

--- a/apps/api/src/routes/admin/users.ts
+++ b/apps/api/src/routes/admin/users.ts
@@ -41,7 +41,7 @@ adminUsers.get("/", async (c) => {
         .offset(offset);
     },
   });
-  const [{ total }] = countRows;
+  const total = countRows[0]?.total ?? 0;
 
   return c.json({ users, total, page, limit });
 });

--- a/apps/api/src/workers/challenge-submission.worker.ts
+++ b/apps/api/src/workers/challenge-submission.worker.ts
@@ -4,6 +4,7 @@ import {
   createQueue,
   QUEUE_NAMES,
 } from "@kubeasy/jobs";
+import { all } from "better-all";
 import { Worker } from "bullmq";
 import { and, count, eq } from "drizzle-orm";
 import { db } from "../db/index";
@@ -56,40 +57,46 @@ export function createChallengeSubmissionWorker() {
         isFirstChallenge,
       );
 
-      // 5. Dispatch XP_AWARD jobs
-      // Base XP always awarded
-      await xpAwardQueue.add("xp-base", {
-        userId,
-        challengeId,
-        challengeSlug,
-        xpAmount: xpGain.baseXP,
-        action: "challenge_completed",
-        description: `Completed ${difficulty} challenge`,
-      } satisfies XpAwardPayload);
-
-      // First challenge bonus
-      if (isFirstChallenge && xpGain.firstChallengeBonus > 0) {
-        await xpAwardQueue.add("xp-first-challenge", {
-          userId,
-          challengeId,
-          challengeSlug,
-          xpAmount: xpGain.firstChallengeBonus,
-          action: "first_challenge",
-          description: "First challenge bonus",
-        } satisfies XpAwardPayload);
-      }
-
-      // Streak bonus
-      if (xpGain.streakBonus > 0) {
-        await xpAwardQueue.add("xp-streak", {
-          userId,
-          challengeId,
-          challengeSlug,
-          xpAmount: xpGain.streakBonus,
-          action: "daily_streak",
-          description: `${currentStreak} day streak bonus`,
-        } satisfies XpAwardPayload);
-      }
+      // 5. Dispatch XP_AWARD jobs in parallel
+      await all({
+        // Base XP always awarded
+        async base() {
+          return xpAwardQueue.add("xp-base", {
+            userId,
+            challengeId,
+            challengeSlug,
+            xpAmount: xpGain.baseXP,
+            action: "challenge_completed",
+            description: `Completed ${difficulty} challenge`,
+          } satisfies XpAwardPayload);
+        },
+        // First challenge bonus
+        async firstChallenge() {
+          if (isFirstChallenge && xpGain.firstChallengeBonus > 0) {
+            return xpAwardQueue.add("xp-first-challenge", {
+              userId,
+              challengeId,
+              challengeSlug,
+              xpAmount: xpGain.firstChallengeBonus,
+              action: "first_challenge",
+              description: "First challenge bonus",
+            } satisfies XpAwardPayload);
+          }
+        },
+        // Streak bonus
+        async streak() {
+          if (xpGain.streakBonus > 0) {
+            return xpAwardQueue.add("xp-streak", {
+              userId,
+              challengeId,
+              challengeSlug,
+              xpAmount: xpGain.streakBonus,
+              action: "daily_streak",
+              description: `${currentStreak} day streak bonus`,
+            } satisfies XpAwardPayload);
+          }
+        },
+      });
     },
     { connection, concurrency: 5 },
   );

--- a/apps/api/src/workers/challenge-submission.worker.ts
+++ b/apps/api/src/workers/challenge-submission.worker.ts
@@ -25,20 +25,25 @@ export function createChallengeSubmissionWorker() {
     async (job) => {
       const { userId, challengeSlug, challengeId, difficulty } = job.data;
 
-      // 1. Check if this is the user's first completed challenge
-      const [completedTransactions] = await db
-        .select({ count: count() })
-        .from(userXpTransaction)
-        .where(
-          and(
-            eq(userXpTransaction.userId, userId),
-            eq(userXpTransaction.action, "challenge_completed"),
-          ),
-        );
+      // 1 & 2. Check first challenge + calculate streak in parallel (independent DB queries)
+      const { completedTransactions, currentStreak } = await all({
+        async completedTransactions() {
+          const [row] = await db
+            .select({ count: count() })
+            .from(userXpTransaction)
+            .where(
+              and(
+                eq(userXpTransaction.userId, userId),
+                eq(userXpTransaction.action, "challenge_completed"),
+              ),
+            );
+          return row;
+        },
+        async currentStreak() {
+          return calculateStreak(userId);
+        },
+      });
       const isFirstChallenge = (completedTransactions?.count ?? 0) === 0;
-
-      // 2. Calculate streak
-      const currentStreak = await calculateStreak(userId);
 
       // 3. Calculate XP amounts
       const xpGain = calculateXPGain({


### PR DESCRIPTION
## Summary

- Parallelize two independent DB queries in `GET /admin/challenges/stats` (submission stats + progress stats) using `better-all`
- Parallelize user count + user list queries in `GET /admin/users/` using `better-all`
- Parallelize up to 3 `xpAwardQueue.add()` Redis round-trips in the challenge submission worker using `better-all`

Closes #26
Closes #35

## Test plan

- [ ] Admin challenges stats page loads correctly
- [ ] Admin users list shows correct total count and paginated results
- [ ] XP is awarded correctly after challenge submission (base, first-challenge, and streak bonuses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)