### PR TITLE
fix(web): address major UI audit findings

### DIFF
--- a/apps/web/src/components/challenges-filters.tsx
+++ b/apps/web/src/components/challenges-filters.tsx
@@ -75,6 +75,7 @@ export function ChallengesFilters({
       <div className="relative flex-[2]">
         <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground z-10" />
         <Input
+          aria-label="Search challenges"
           placeholder="Search challenges..."
           value={search}
           onChange={(e) => handleSearchChange(e.target.value)}

--- a/apps/web/src/components/challenges-quick-start-cta.tsx
+++ b/apps/web/src/components/challenges-quick-start-cta.tsx
@@ -1,15 +1,22 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight, Terminal } from "lucide-react";
+import { useEffect, useState } from "react";
 import { authClient } from "@/lib/auth-client";
 
 /**
- * Quick start CTA shown only to unauthenticated users
+ * Quick start CTA shown only to unauthenticated users.
+ * Uses a mounted guard to avoid SSR/client hydration mismatch,
+ * since authClient.useSession() returns different state on server vs client.
  */
 export function ChallengesQuickStartCTA() {
+  const [mounted, setMounted] = useState(false);
   const { data: session, isPending } = authClient.useSession();
 
-  // Don't show while loading or if user is authenticated
-  if (isPending || session) {
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || isPending || session) {
     return null;
   }
 

--- a/apps/web/src/components/challenges-quick-start-cta.tsx
+++ b/apps/web/src/components/challenges-quick-start-cta.tsx
@@ -16,9 +16,12 @@ export function ChallengesQuickStartCTA() {
     setMounted(true);
   }, []);
 
-  if (!mounted || isPending || session) {
-    return null;
+  // Reserve space during SSR and session loading to avoid layout shift
+  if (!mounted || isPending) {
+    return <div className="mb-8 h-[72px]" />;
   }
+
+  if (session) return null;
 
   return (
     <div className="mb-8 p-4 bg-secondary neo-border-thick neo-shadow flex flex-col sm:flex-row items-center justify-between gap-4">

--- a/apps/web/src/components/difficulty-badge.tsx
+++ b/apps/web/src/components/difficulty-badge.tsx
@@ -31,7 +31,7 @@ export function DifficultyBadge({
         difficultySizes[size],
       )}
     >
-      {difficultyLabels[difficulty] ?? difficulty}
+      {difficultyLabels[difficulty]}
     </Badge>
   );
 }

--- a/apps/web/src/components/difficulty-badge.tsx
+++ b/apps/web/src/components/difficulty-badge.tsx
@@ -1,5 +1,6 @@
 import type { ChallengeDifficulty } from "@kubeasy/api-schemas/challenges";
 import { Badge } from "@kubeasy/ui/badge";
+import { difficultyLabels } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 const difficultyColors: Record<ChallengeDifficulty, string> = {
@@ -25,12 +26,12 @@ export function DifficultyBadge({
     <Badge
       variant="outline"
       className={cn(
-        "capitalize border-black neo-border",
+        "border-black neo-border",
         difficultyColors[difficulty],
         difficultySizes[size],
       )}
     >
-      {difficulty}
+      {difficultyLabels[difficulty] ?? difficulty}
     </Badge>
   );
 }

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -12,7 +12,7 @@ export function Footer() {
             <Link to="/" className="flex items-center gap-2">
               <Image
                 src="/logo.png"
-                alt={siteConfig.name}
+                alt=""
                 width={32}
                 height={32}
                 className="h-8 w-8"
@@ -134,6 +134,7 @@ export function Footer() {
               href={siteConfig.links.github}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="GitHub"
               className="hover:text-primary transition-colors"
             >
               <Github className="h-5 w-5" />
@@ -142,6 +143,7 @@ export function Footer() {
               href={siteConfig.links.twitter}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="X (Twitter)"
               className="hover:text-primary transition-colors"
             >
               <Twitter className="h-5 w-5" />

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -27,7 +27,7 @@ export function Header() {
         <Link to="/" className="flex items-center gap-3">
           <Image
             src="/logo.png"
-            alt={siteConfig.name}
+            alt=""
             width={40}
             height={40}
             className="h-10 w-10"

--- a/apps/web/src/lib/blog.functions.ts
+++ b/apps/web/src/lib/blog.functions.ts
@@ -17,12 +17,15 @@ export const fetchBlogPostDetailFn = createServerFn({ method: "GET" })
   .handler(
     async ({
       data: slug,
-    }): Promise<{ post: BlogPostWithContent; relatedPosts: BlogPost[] }> => {
+    }): Promise<{
+      post: BlogPostWithContent;
+      relatedPosts: BlogPost[];
+    } | null> => {
       const [post, allPosts] = await Promise.all([
         getBlogPostWithContent(slug),
         getBlogPosts(),
       ]);
-      if (!post) throw new Error(`Blog post not found: ${slug}`);
+      if (!post) return null;
       const relatedPosts = await getRelatedBlogPosts(post, 3, allPosts);
       return { post, relatedPosts };
     },

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -5,6 +5,10 @@ export const difficulties = [
   { value: "hard", label: "Advanced" },
 ];
 
+export const difficultyLabels: Record<string, string> = Object.fromEntries(
+  difficulties.filter((d) => d.value !== "all").map((d) => [d.value, d.label]),
+);
+
 const githubOwner = "kubeasy-dev";
 
 export const siteConfig = {

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -5,9 +5,13 @@ export const difficulties = [
   { value: "hard", label: "Advanced" },
 ];
 
-export const difficultyLabels: Record<string, string> = Object.fromEntries(
-  difficulties.filter((d) => d.value !== "all").map((d) => [d.value, d.label]),
-);
+import type { ChallengeDifficulty } from "@kubeasy/api-schemas/challenges";
+
+export const difficultyLabels: Record<ChallengeDifficulty, string> = {
+  easy: "Beginner",
+  medium: "Intermediate",
+  hard: "Advanced",
+};
 
 const githubOwner = "kubeasy-dev";
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import {
   createRootRouteWithContext,
   HeadContent,
+  Link,
   Outlet,
   Scripts,
   useRouterState,
@@ -20,7 +21,28 @@ interface RouterContext {
   queryClient: QueryClient;
 }
 
+function NotFoundPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <div className="neo-border-thick neo-shadow bg-secondary p-10 max-w-md w-full">
+        <p className="text-6xl font-black text-primary mb-4">404</p>
+        <h1 className="text-2xl font-black mb-3">Page Not Found</h1>
+        <p className="text-muted-foreground font-medium mb-8">
+          The page you're looking for doesn't exist or has been moved.
+        </p>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 bg-primary text-primary-foreground px-6 py-3 font-bold neo-border hover:translate-x-0.5 hover:translate-y-0.5 transition-transform"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 export const Route = createRootRouteWithContext<RouterContext>()({
+  notFoundComponent: NotFoundPage,
   head: () => ({
     meta: [
       { charSet: "utf-8" },

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -24,6 +24,7 @@ interface RouterContext {
 function NotFoundPage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center">
+      <title>404 — Page Not Found | Kubeasy</title>
       <div className="neo-border-thick neo-shadow bg-secondary p-10 max-w-md w-full">
         <p className="text-6xl font-black text-primary mb-4">404</p>
         <h1 className="text-2xl font-black mb-3">Page Not Found</h1>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { Calendar, ChevronLeft, Clock } from "lucide-react";
 import { lazy, Suspense } from "react";
 import { AuthorCard } from "@/components/author-card";
@@ -17,7 +17,10 @@ export const Route = createFileRoute("/blog/$slug")({
       "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800",
   }),
   loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.ensureQueryData(blogPostDetailOptions(params.slug));
+    const data = await queryClient.ensureQueryData(
+      blogPostDetailOptions(params.slug),
+    );
+    if (!data) throw notFound();
   },
   component: BlogArticlePage,
 });
@@ -244,6 +247,10 @@ function BlockItem({ block }: { block: NotionBlock }) {
 function BlogArticlePage() {
   const { slug } = Route.useParams();
   const { data } = useSuspenseQuery(blogPostDetailOptions(slug));
+
+  // The loader already throws notFound() when data is null, so this is unreachable at runtime
+  if (!data) return null;
+
   const { post, relatedPosts } = data;
 
   const wordCount = post.blocks

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -55,7 +55,7 @@ function renderRichText(items: RichTextItem[]): React.ReactNode {
       );
     }
 
-    return <span key={i}>{content}</span>;
+    return <span key={`${item.plain_text}-${i}`}>{content}</span>;
   });
 }
 


### PR DESCRIPTION
## Summary

- **404 pages** — Added `notFoundComponent` to the root route; blog loader now throws `notFound()` instead of a generic `Error` for unknown slugs, so all unknown routes (`/challenges/:slug`, `/blog/:slug`, `/themes/:slug`, `/types/:slug`) show a proper 404 page instead of an error boundary
- **SSR hydration mismatch** — Fixed `ChallengesQuickStartCTA` with a `mounted` guard so server and client render the same output on first paint
- **Difficulty labels** — `DifficultyBadge` now uses `difficultyLabels` from constants so badges say "Beginner/Intermediate/Advanced", matching the filter dropdown
- **Accessibility** — Added `aria-label` to footer social icon links (GitHub, X/Twitter) and challenges search input; set decorative logo images to `alt=""`

## Test plan

- [ ] Navigate to `/challenges/nonexistent-slug` → should show "Page Not Found" with a back-to-home link
- [ ] Navigate to `/blog/nonexistent-slug` → same 404 page
- [ ] Open `/challenges` in incognito → no hydration warning in the browser console
- [ ] Check difficulty badges on challenge cards say "Beginner / Intermediate / Advanced"
- [ ] Run axe-core on homepage and `/challenges` → no `link-name` serious violations on footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)