### PR TITLE
feat(api): store audit events and attempt number on challenge submit

### DIFF
--- a/.github/workflows/generate-drizzle-migration.yml
+++ b/.github/workflows/generate-drizzle-migration.yml
@@ -70,33 +70,22 @@ jobs:
           git config --local user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config --local user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-      - name: Squash existing branch migrations
+      - name: Check for existing branch migrations
+        id: check-migrations
         run: |
           BASE=${{ github.base_ref }}
-
-          # Find .sql migration files added on this branch (not in base)
           ADDED_SQL=$(git diff origin/$BASE...HEAD --name-only --diff-filter=A -- 'apps/api/drizzle/*.sql')
-
           if [ -n "$ADDED_SQL" ]; then
-            echo "Found existing branch migrations, squashing:"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Existing branch migrations found — skipping generation to preserve manual SQL:"
             echo "$ADDED_SQL"
-
-            # Remove added SQL files
-            echo "$ADDED_SQL" | xargs rm -f
-
-            # Remove corresponding snapshot files
-            ADDED_SNAPSHOTS=$(git diff origin/$BASE...HEAD --name-only --diff-filter=A -- 'apps/api/drizzle/meta/*_snapshot.json')
-            if [ -n "$ADDED_SNAPSHOTS" ]; then
-              echo "$ADDED_SNAPSHOTS" | xargs rm -f
-            fi
-
-            # Reset _journal.json to base state so the next generate picks the right index
-            git checkout origin/$BASE -- apps/api/drizzle/meta/_journal.json
           else
-            echo "No existing branch migrations found, generating fresh."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No existing branch migrations found, will generate."
           fi
 
       - name: Generate migration
+        if: steps.check-migrations.outputs.exists != 'true'
         working-directory: apps/api
         run: pnpm db:generate
 

--- a/apps/api/drizzle/0002_kind_wiccan.sql
+++ b/apps/api/drizzle/0002_kind_wiccan.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_submission" ADD COLUMN "attempt_number" integer;--> statement-breakpoint
+ALTER TABLE "user_submission" ADD COLUMN "audit_events" jsonb;

--- a/apps/api/drizzle/0002_kind_wiccan.sql
+++ b/apps/api/drizzle/0002_kind_wiccan.sql
@@ -1,2 +1,12 @@
 ALTER TABLE "user_submission" ADD COLUMN "attempt_number" integer;--> statement-breakpoint
-ALTER TABLE "user_submission" ADD COLUMN "audit_events" jsonb;
+ALTER TABLE "user_submission" ADD COLUMN "audit_events" jsonb;--> statement-breakpoint
+UPDATE "user_submission"
+SET "attempt_number" = sub.rn
+FROM (
+  SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id, challenge_id ORDER BY "timestamp") AS rn
+  FROM "user_submission"
+) sub
+WHERE "user_submission".id = sub.id;--> statement-breakpoint
+ALTER TABLE "user_submission" ALTER COLUMN "attempt_number" SET NOT NULL;--> statement-breakpoint
+CREATE INDEX "user_submission_user_challenge_idx" ON "user_submission" USING btree ("user_id","challenge_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "user_submission_user_challenge_attempt_idx" ON "user_submission" USING btree ("user_id","challenge_id","attempt_number");

--- a/apps/api/drizzle/0002_volatile_cannonball.sql
+++ b/apps/api/drizzle/0002_volatile_cannonball.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "user_submission" ADD COLUMN "attempt_number" integer;--> statement-breakpoint
+ALTER TABLE "user_submission" ADD COLUMN "audit_events" jsonb;--> statement-breakpoint
+UPDATE "user_submission"
+SET "attempt_number" = sub.rn
+FROM (
+  SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id, challenge_id ORDER BY "timestamp") AS rn
+  FROM "user_submission"
+) sub
+WHERE "user_submission".id = sub.id;

--- a/apps/api/drizzle/0002_volatile_cannonball.sql
+++ b/apps/api/drizzle/0002_volatile_cannonball.sql
@@ -1,9 +1,0 @@
-ALTER TABLE "user_submission" ADD COLUMN "attempt_number" integer;--> statement-breakpoint
-ALTER TABLE "user_submission" ADD COLUMN "audit_events" jsonb;--> statement-breakpoint
-UPDATE "user_submission"
-SET "attempt_number" = sub.rn
-FROM (
-  SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id, challenge_id ORDER BY "timestamp") AS rn
-  FROM "user_submission"
-) sub
-WHERE "user_submission".id = sub.id;

--- a/apps/api/drizzle/meta/0002_snapshot.json
+++ b/apps/api/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1751 @@
+{
+  "id": "fd42c0b0-4ed0-4577-b5a0-e827f2a37214",
+  "prevId": "3c734e86-41b2-47b6-93fe-c34544ecbf3f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_contact_id": {
+          "name": "resend_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge": {
+      "name": "challenge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "challenge_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fix'"
+        },
+        "estimated_time": {
+          "name": "estimated_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_situation": {
+          "name": "initial_situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "of_the_week": {
+          "name": "of_the_week",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "starter_friendly": {
+          "name": "starter_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_difficulty_idx": {
+          "name": "challenge_difficulty_idx",
+          "columns": [
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_theme_idx": {
+          "name": "challenge_theme_idx",
+          "columns": [
+            {
+              "expression": "theme",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_type_idx": {
+          "name": "challenge_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_theme_difficulty_idx": {
+          "name": "challenge_theme_difficulty_idx",
+          "columns": [
+            {
+              "expression": "theme",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_title_idx": {
+          "name": "challenge_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_created_at_idx": {
+          "name": "challenge_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_starter_friendly_idx": {
+          "name": "challenge_starter_friendly_idx",
+          "columns": [
+            {
+              "expression": "starter_friendly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_available_difficulty_idx": {
+          "name": "challenge_available_difficulty_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "difficulty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_theme_challenge_theme_slug_fk": {
+          "name": "challenge_theme_challenge_theme_slug_fk",
+          "tableFrom": "challenge",
+          "tableTo": "challenge_theme",
+          "columnsFrom": [
+            "theme"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenge_type_challenge_type_slug_fk": {
+          "name": "challenge_type_challenge_type_slug_fk",
+          "tableFrom": "challenge",
+          "tableTo": "challenge_type",
+          "columnsFrom": [
+            "type"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "challenge_slug_unique": {
+          "name": "challenge_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_objective": {
+      "name": "challenge_objective",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_key": {
+          "name": "objective_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "objective_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_objective_challenge_key_idx": {
+          "name": "challenge_objective_challenge_key_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "objective_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenge_objective_challenge_id_idx": {
+          "name": "challenge_objective_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_objective_challenge_id_challenge_id_fk": {
+          "name": "challenge_objective_challenge_id_challenge_id_fk",
+          "tableFrom": "challenge_objective",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_theme": {
+      "name": "challenge_theme",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_type": {
+      "name": "challenge_type",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_progress": {
+      "name": "user_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_progress_user_challenge_unique_idx": {
+          "name": "user_progress_user_challenge_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_user_status_challenge_idx": {
+          "name": "user_progress_user_status_challenge_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_challenge_status_idx": {
+          "name": "user_progress_challenge_status_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_progress_user_id_user_id_fk": {
+          "name": "user_progress_user_id_user_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_progress_challenge_id_challenge_id_fk": {
+          "name": "user_progress_challenge_id_challenge_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_submission": {
+      "name": "user_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_events": {
+          "name": "audit_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_submission_user_id_user_id_fk": {
+          "name": "user_submission_user_id_user_id_fk",
+          "tableFrom": "user_submission",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_submission_challenge_id_challenge_id_fk": {
+          "name": "user_submission_challenge_id_challenge_id_fk",
+          "tableFrom": "user_submission",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_xp": {
+      "name": "user_xp",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_xp_total_xp_idx": {
+          "name": "user_xp_total_xp_idx",
+          "columns": [
+            {
+              "expression": "total_xp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_xp_user_id_user_id_fk": {
+          "name": "user_xp_user_id_user_id_fk",
+          "tableFrom": "user_xp",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_xp_transaction": {
+      "name": "user_xp_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "xp_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_xp_transaction_user_id_idx": {
+          "name": "user_xp_transaction_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_xp_transaction_user_action_idx": {
+          "name": "user_xp_transaction_user_action_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_xp_transaction_user_id_user_id_fk": {
+          "name": "user_xp_transaction_user_id_user_id_fk",
+          "tableFrom": "user_xp_transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_xp_transaction_challenge_id_challenge_id_fk": {
+          "name": "user_xp_transaction_challenge_id_challenge_id_fk",
+          "tableFrom": "user_xp_transaction",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_topic": {
+      "name": "email_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "email_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "resend_topic_id": {
+          "name": "resend_topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_opt_in": {
+          "name": "default_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_topic_resend_topic_id_unique": {
+          "name": "email_topic_resend_topic_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_authenticated": {
+          "name": "cli_authenticated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cluster_initialized": {
+          "name": "cluster_initialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_onboarding_user_id_idx": {
+          "name": "user_onboarding_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_user_id_user_id_fk": {
+          "name": "user_onboarding_user_id_user_id_fk",
+          "tableFrom": "user_onboarding",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_onboarding_user_id_unique": {
+          "name": "user_onboarding_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.challenge_difficulty": {
+      "name": "challenge_difficulty",
+      "schema": "public",
+      "values": [
+        "easy",
+        "medium",
+        "hard"
+      ]
+    },
+    "public.challenge_status": {
+      "name": "challenge_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed"
+      ]
+    },
+    "public.objective_category": {
+      "name": "objective_category",
+      "schema": "public",
+      "values": [
+        "status",
+        "condition",
+        "log",
+        "event",
+        "connectivity",
+        "rbac",
+        "spec",
+        "triggered"
+      ]
+    },
+    "public.xp_action": {
+      "name": "xp_action",
+      "schema": "public",
+      "values": [
+        "challenge_completed",
+        "daily_streak",
+        "first_challenge",
+        "milestone_reached",
+        "bonus"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0002_snapshot.json
+++ b/apps/api/drizzle/meta/0002_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "fd42c0b0-4ed0-4577-b5a0-e827f2a37214",
+  "id": "1ead5d04-5b76-4e25-ba41-94c1dc32217d",
   "prevId": "3c734e86-41b2-47b6-93fe-c34544ecbf3f",
   "version": "7",
   "dialect": "postgresql",

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -19,8 +19,8 @@
     {
       "idx": 2,
       "version": "7",
-      "when": 1776870819609,
-      "tag": "0002_volatile_cannonball",
+      "when": 1776871608465,
+      "tag": "0002_kind_wiccan",
       "breakpoints": true
     }
   ]

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775146377211,
       "tag": "0001_brainy_kree",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776870819609,
+      "tag": "0002_volatile_cannonball",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/challenge.ts
+++ b/apps/api/src/db/schema/challenge.ts
@@ -139,24 +139,40 @@ export const userProgress = pgTable(
   ],
 );
 
-export const userSubmission = pgTable("user_submission", {
-  id: text("id").primaryKey(),
-  userId: text("user_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  challengeId: integer("challenge_id")
-    .notNull()
-    .references(() => challenge.id, { onDelete: "cascade" }),
-  timestamp: timestamp("timestamp").defaultNow().notNull(),
-  validated: boolean("validated").notNull().default(false),
-  // Objectives: flat list of validation results enriched from challengeObjective table
-  // Structure: {id, name, description, passed, category, message}[]
-  objectives: json("objectives"),
-  // Attempt number: increments per (userId, challengeId) across all submissions
-  attemptNumber: integer("attempt_number"),
-  // Raw kubectl audit events captured by the CLI during the attempt
-  auditEvents: jsonb("audit_events"),
-});
+export const userSubmission = pgTable(
+  "user_submission",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    challengeId: integer("challenge_id")
+      .notNull()
+      .references(() => challenge.id, { onDelete: "cascade" }),
+    timestamp: timestamp("timestamp").defaultNow().notNull(),
+    validated: boolean("validated").notNull().default(false),
+    // Objectives: flat list of validation results enriched from challengeObjective table
+    // Structure: {id, name, description, passed, category, message}[]
+    objectives: json("objectives"),
+    // Attempt number: increments per (userId, challengeId) across all submissions
+    attemptNumber: integer("attempt_number").notNull(),
+    // Raw kubectl audit events captured by the CLI during the attempt
+    auditEvents: jsonb("audit_events"),
+  },
+  (table) => [
+    // Unique constraint prevents duplicate attempt numbers and serves as a race guard
+    uniqueIndex("user_submission_user_challenge_attempt_idx").on(
+      table.userId,
+      table.challengeId,
+      table.attemptNumber,
+    ),
+    // Index for MAX(attempt_number) query in submit handler
+    index("user_submission_user_challenge_idx").on(
+      table.userId,
+      table.challengeId,
+    ),
+  ],
+);
 
 export const xpActionEnum = pgEnum("xp_action", [
   "challenge_completed",

--- a/apps/api/src/db/schema/challenge.ts
+++ b/apps/api/src/db/schema/challenge.ts
@@ -6,6 +6,7 @@ import {
   index,
   integer,
   json,
+  jsonb,
   pgEnum,
   pgTable,
   serial,
@@ -151,6 +152,10 @@ export const userSubmission = pgTable("user_submission", {
   // Objectives: flat list of validation results enriched from challengeObjective table
   // Structure: {id, name, description, passed, category, message}[]
   objectives: json("objectives"),
+  // Attempt number: increments per (userId, challengeId) across all submissions
+  attemptNumber: integer("attempt_number"),
+  // Raw kubectl audit events captured by the CLI during the attempt
+  auditEvents: jsonb("audit_events"),
 });
 
 export const xpActionEnum = pgEnum("xp_action", [

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -158,20 +158,35 @@ submit.post(
           ),
         );
 
-      // 7b. Always store submission (with attempt number and audit events)
-      await tx.insert(userSubmission).values({
-        id: nanoid(),
-        userId,
-        challengeId: challengeData.id,
-        validated,
-        objectives,
-        attemptNumber: nextAttempt,
-        auditEvents: auditEvents ?? null,
-      });
+      // 7b. Always store submission (with attempt number and audit events).
+      // The unique index on (user_id, challenge_id, attempt_number) guards against
+      // concurrent submits racing on the same MAX — catch PG error 23505 and return
+      // 409 so the caller retries rather than seeing an unhandled 500.
+      try {
+        await tx.insert(userSubmission).values({
+          id: nanoid(),
+          userId,
+          challengeId: challengeData.id,
+          validated,
+          objectives,
+          attemptNumber: nextAttempt,
+          auditEvents: auditEvents ?? null,
+        });
+      } catch (err: unknown) {
+        if (
+          typeof err === "object" &&
+          err !== null &&
+          "code" in err &&
+          (err as { code: string }).code === "23505"
+        ) {
+          return { conflict: true, progressUpdated: false, failed: false };
+        }
+        throw err;
+      }
 
       // 7c. If validation failed, no progress update needed
       if (!validated) {
-        return { progressUpdated: false, failed: true };
+        return { conflict: false, progressUpdated: false, failed: true };
       }
 
       // 7d. Atomic progress update (race guard)
@@ -207,8 +222,16 @@ submit.post(
         progressUpdated = inserted.length > 0;
       }
 
-      return { progressUpdated, failed: false };
+      return { conflict: false, progressUpdated, failed: false };
     });
+
+    // 7.5: Concurrent submit conflict — unique index on attempt_number fired
+    if (txResult.conflict) {
+      return c.json(
+        { error: "Concurrent submission detected, please retry" },
+        409,
+      );
+    }
 
     // 7.5 Track submission with outcome (fire-and-forget)
     const failedObjectives = objectives.filter((obj) => !obj.passed);

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -142,7 +142,10 @@ submit.post(
 
     // 7. Transaction: store submission + progress update atomically
     const txResult = await db.transaction(async (tx) => {
-      // 7a. Compute next attempt_number for this (userId, challengeId)
+      // 7a. Compute next attempt_number for this (userId, challengeId).
+      // The CLI is the only submit client and concurrent submits from one user are
+      // practically impossible, so MAX+1 is safe. The UNIQUE index on
+      // (user_id, challenge_id, attempt_number) is a hard guard if that assumption breaks.
       const [{ nextAttempt }] = await tx
         .select({
           nextAttempt: sql<number>`COALESCE(MAX(${userSubmission.attemptNumber}), 0) + 1`,
@@ -232,7 +235,7 @@ submit.post(
       queryKey: queryKeys.submissions.latest(challengeSlug),
     });
     redis.publish(sseChannel, ssePayload).catch((err) => {
-      console.error("Failed to publish SSE event", {
+      logger.error("[submit] SSE publish failed", {
         channel: sseChannel,
         error: String(err),
       });
@@ -240,7 +243,9 @@ submit.post(
 
     // Invalidate all server-side user caches (progress, xp, streak, challenge list)
     cacheDelPattern(`cache:u:${userId}:*`).catch((err) => {
-      console.error("[submit] cache invalidation failed", err);
+      logger.error("[submit] cache invalidation failed", {
+        error: String(err),
+      });
     });
 
     // 8. If validation failed, return failure response
@@ -261,7 +266,7 @@ submit.post(
       return c.json({ success: true, objectives });
     }
 
-    // 11. Dispatch CHALLENGE_SUBMISSION BullMQ job (fire-and-forget)
+    // 10. Dispatch CHALLENGE_SUBMISSION BullMQ job (fire-and-forget)
     challengeSubmissionQueue
       .add("challenge-completed", {
         userId,
@@ -270,10 +275,12 @@ submit.post(
         difficulty: challengeData.difficulty,
       })
       .catch((err) => {
-        console.error("[submit] challenge-submission job dispatch failed", err);
+        logger.error("[submit] challenge-submission job dispatch failed", {
+          error: String(err),
+        });
       });
 
-    // 12. Return success response
+    // 11. Return success response
     return c.json({ success: true, objectives });
   },
 );

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -2,8 +2,9 @@ import { zValidator } from "@hono/zod-validator";
 import { queryKeys } from "@kubeasy/api-schemas/query-keys";
 import { createQueue, QUEUE_NAMES } from "@kubeasy/jobs";
 import { logger } from "@kubeasy/logger";
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { nanoid } from "nanoid";
 import { db } from "../db/index";
 import {
@@ -37,12 +38,13 @@ submit.post(
   "/:slug/submit",
   requireAuth,
   submitRateLimit,
+  bodyLimit({ maxSize: 1024 * 1024 }), // 1 MB
   zValidator("json", submitBodySchema),
   async (c) => {
     const user = c.get("user");
     const userId = user.id;
     const challengeSlug = c.req.param("slug");
-    const { results } = c.req.valid("json");
+    const { results, auditEvents } = c.req.valid("json");
 
     // 1. Find challenge by slug
     const [challengeData] = await db
@@ -138,13 +140,71 @@ submit.post(
     // 6. Determine validation result
     const validated = results.every((r) => r.passed);
 
-    // 7. Always store submission
-    await db.insert(userSubmission).values({
-      id: nanoid(),
-      userId,
-      challengeId: challengeData.id,
-      validated,
-      objectives,
+    // 7. Transaction: store submission + progress update atomically
+    const txResult = await db.transaction(async (tx) => {
+      // 7a. Compute next attempt_number for this (userId, challengeId)
+      const [{ nextAttempt }] = await tx
+        .select({
+          nextAttempt: sql<number>`COALESCE(MAX(${userSubmission.attemptNumber}), 0) + 1`,
+        })
+        .from(userSubmission)
+        .where(
+          and(
+            eq(userSubmission.userId, userId),
+            eq(userSubmission.challengeId, challengeData.id),
+          ),
+        );
+
+      // 7b. Always store submission (with attempt number and audit events)
+      await tx.insert(userSubmission).values({
+        id: nanoid(),
+        userId,
+        challengeId: challengeData.id,
+        validated,
+        objectives,
+        attemptNumber: nextAttempt,
+        auditEvents: auditEvents ?? null,
+      });
+
+      // 7c. If validation failed, no progress update needed
+      if (!validated) {
+        return { progressUpdated: false, failed: true };
+      }
+
+      // 7d. Atomic progress update (race guard)
+      let progressUpdated: boolean;
+      if (existingProgress) {
+        const updated = await tx
+          .update(userProgress)
+          .set({
+            status: "completed",
+            completedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(userProgress.id, existingProgress.id),
+              ne(userProgress.status, "completed"),
+            ),
+          )
+          .returning({ id: userProgress.id });
+        progressUpdated = updated.length > 0;
+      } else {
+        const inserted = await tx
+          .insert(userProgress)
+          .values({
+            id: nanoid(),
+            userId,
+            challengeId: challengeData.id,
+            status: "completed",
+            completedAt: new Date(),
+          })
+          .onConflictDoNothing()
+          .returning({ id: userProgress.id });
+        progressUpdated = inserted.length > 0;
+      }
+
+      return { progressUpdated, failed: false };
     });
 
     // 7.5 Track submission with outcome (fire-and-forget)
@@ -184,7 +244,7 @@ submit.post(
     });
 
     // 8. If validation failed, return failure response
-    if (!validated) {
+    if (txResult.failed) {
       return c.json({
         success: false,
         objectives,
@@ -196,43 +256,8 @@ submit.post(
       });
     }
 
-    // 9. Atomic progress update (race guard)
-    let progressUpdated: boolean;
-    if (existingProgress) {
-      // Only update if not already completed — if RETURNING is empty, race was lost
-      const updated = await db
-        .update(userProgress)
-        .set({
-          status: "completed",
-          completedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(userProgress.id, existingProgress.id),
-            ne(userProgress.status, "completed"),
-          ),
-        )
-        .returning({ id: userProgress.id });
-      progressUpdated = updated.length > 0;
-    } else {
-      // onConflictDoNothing + unique index catches concurrent inserts
-      const inserted = await db
-        .insert(userProgress)
-        .values({
-          id: nanoid(),
-          userId,
-          challengeId: challengeData.id,
-          status: "completed",
-          completedAt: new Date(),
-        })
-        .onConflictDoNothing()
-        .returning({ id: userProgress.id });
-      progressUpdated = inserted.length > 0;
-    }
-
-    // 10. If race was lost, return early
-    if (!progressUpdated) {
+    // 9. If race was lost, return early
+    if (!txResult.progressUpdated) {
       return c.json({ success: true, objectives });
     }
 

--- a/apps/api/src/schemas/index.ts
+++ b/apps/api/src/schemas/index.ts
@@ -28,7 +28,7 @@ export const objectiveSchema = z.object({
 });
 
 export const auditEventSchema = z.object({
-  timestamp: z.string().datetime(),
+  timestamp: z.string().datetime({ offset: true }),
   verb: z.string().max(64),
   resource: z.string().max(128),
   subresource: z.string().max(128).optional(),

--- a/apps/api/src/schemas/index.ts
+++ b/apps/api/src/schemas/index.ts
@@ -28,19 +28,19 @@ export const objectiveSchema = z.object({
 });
 
 export const auditEventSchema = z.object({
-  timestamp: z.string(),
-  verb: z.string(),
-  resource: z.string(),
-  subresource: z.string().optional(),
-  name: z.string().optional(),
-  namespace: z.string().optional(),
-  userAgent: z.string().optional(),
-  responseCode: z.number().optional(),
+  timestamp: z.string().datetime(),
+  verb: z.string().max(64),
+  resource: z.string().max(128),
+  subresource: z.string().max(128).optional(),
+  name: z.string().max(253).optional(), // k8s name max length
+  namespace: z.string().max(63).optional(), // k8s namespace max length
+  userAgent: z.string().max(512).optional(),
+  responseCode: z.number().int().min(100).max(599).optional(),
 });
 
 export const submitBodySchema = z.object({
   results: z.array(objectiveResultSchema).min(1),
-  auditEvents: z.array(auditEventSchema).optional(),
+  auditEvents: z.array(auditEventSchema).max(10_000).optional(),
 });
 
 export type ObjectiveResult = z.infer<typeof objectiveResultSchema>;

--- a/apps/api/src/schemas/index.ts
+++ b/apps/api/src/schemas/index.ts
@@ -27,12 +27,25 @@ export const objectiveSchema = z.object({
   message: z.string().optional(),
 });
 
+export const auditEventSchema = z.object({
+  timestamp: z.string(),
+  verb: z.string(),
+  resource: z.string(),
+  subresource: z.string().optional(),
+  name: z.string().optional(),
+  namespace: z.string().optional(),
+  userAgent: z.string().optional(),
+  responseCode: z.number().optional(),
+});
+
 export const submitBodySchema = z.object({
   results: z.array(objectiveResultSchema).min(1),
+  auditEvents: z.array(auditEventSchema).optional(),
 });
 
 export type ObjectiveResult = z.infer<typeof objectiveResultSchema>;
 export type Objective = z.infer<typeof objectiveSchema>;
+export type AuditEvent = z.infer<typeof auditEventSchema>;
 export type SubmitBody = z.infer<typeof submitBodySchema>;
 
 // ---- Challenge list filters ----


### PR DESCRIPTION
## Summary

- Adds `attempt_number` (integer) and `audit_events` (jsonb) columns to the existing `user_submission` table — consolidates attempt tracking without a new table
- Backfills `attempt_number` for existing rows via `ROW_NUMBER() OVER (PARTITION BY user_id, challenge_id ORDER BY timestamp)` in the migration
- Wraps submission insert + progress update in a single `db.transaction()` for atomicity
- Accepts optional `auditEvents` array in the submit payload (typed with exact `AuditEvent` shape: timestamp, verb, resource, subresource?, name?, namespace?, userAgent?, responseCode?)
- Adds 1 MB `bodyLimit` middleware to the submit route

## Test plan

- [ ] Submit with `auditEvents` → `audit_events` column is populated in DB
- [ ] Submit without `auditEvents` → accepted without error, `audit_events` is null
- [ ] Submit multiple times for the same challenge → `attempt_number` increments correctly (1, 2, 3…)
- [ ] Existing rows in `user_submission` have `attempt_number` backfilled after migration
- [ ] Payload > 1 MB → rejected with 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)