### PR TITLE
feat(api): preserve XP on challenge replay reset

### DIFF
--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -259,6 +259,27 @@ const handleReset: Handler = async (c) => {
     return c.json({ error: "Challenge not found" }, 404);
   }
 
+  // Read progress BEFORE deletion to capture previous status
+  const [progress] = await db
+    .select()
+    .from(userProgress)
+    .where(
+      and(
+        eq(userProgress.userId, userId),
+        eq(userProgress.challengeSlug, slug),
+      ),
+    )
+    .limit(1);
+
+  if (!progress) {
+    return c.json({
+      success: true,
+      message: "No progress to reset.",
+    });
+  }
+
+  const isReplay = progress.status === "completed";
+
   await Promise.all([
     db
       .delete(userProgress)
@@ -276,14 +297,18 @@ const handleReset: Handler = async (c) => {
           eq(userSubmission.challengeSlug, slug),
         ),
       ),
-    db
-      .delete(userXpTransaction)
-      .where(
-        and(
-          eq(userXpTransaction.userId, userId),
-          eq(userXpTransaction.challengeSlug, slug),
-        ),
-      ),
+    ...(isReplay
+      ? []
+      : [
+          db
+            .delete(userXpTransaction)
+            .where(
+              and(
+                eq(userXpTransaction.userId, userId),
+                eq(userXpTransaction.challengeSlug, slug),
+              ),
+            ),
+        ]),
   ]);
 
   const [xpResult] = await db
@@ -307,7 +332,11 @@ const handleReset: Handler = async (c) => {
 
   return c.json({
     success: true,
-    message: "Challenge progress reset successfully",
+    isReplay,
+    previousStatus: progress.status,
+    message: isReplay
+      ? "Challenge reset. Your XP from the previous completion has been preserved."
+      : "Challenge progress reset successfully.",
   });
 };
 

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -261,7 +261,7 @@ const handleReset: Handler = async (c) => {
 
   // Read progress BEFORE deletion to capture previous status
   const [progress] = await db
-    .select()
+    .select({ status: userProgress.status })
     .from(userProgress)
     .where(
       and(
@@ -311,17 +311,19 @@ const handleReset: Handler = async (c) => {
         ]),
   ]);
 
-  const [xpResult] = await db
-    .select({
-      totalXp: sql<number>`COALESCE(SUM(${userXpTransaction.xpAmount}), 0)`,
-    })
-    .from(userXpTransaction)
-    .where(eq(userXpTransaction.userId, userId));
+  if (!isReplay) {
+    const [xpResult] = await db
+      .select({
+        totalXp: sql<number>`COALESCE(SUM(${userXpTransaction.xpAmount}), 0)`,
+      })
+      .from(userXpTransaction)
+      .where(eq(userXpTransaction.userId, userId));
 
-  await db
-    .update(userXp)
-    .set({ totalXp: xpResult?.totalXp ?? 0 })
-    .where(eq(userXp.userId, userId));
+    await db
+      .update(userXp)
+      .set({ totalXp: xpResult?.totalXp ?? 0 })
+      .where(eq(userXp.userId, userId));
+  }
 
   cacheDelPattern(`cache:u:${userId}:*`).catch((err) => {
     logger.error("[progress/reset] cache invalidation failed", {

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -166,7 +166,25 @@ submit.post(
         progressUpdated = inserted.length > 0;
       }
 
-      return { conflict: false, progressUpdated, failed: false };
+      // 5d. Check for existing XP transaction (replay guard)
+      const [existingXp] = await tx
+        .select({ id: userXpTransaction.id })
+        .from(userXpTransaction)
+        .where(
+          and(
+            eq(userXpTransaction.userId, userId),
+            eq(userXpTransaction.challengeSlug, challengeSlug),
+            eq(userXpTransaction.action, "challenge_completed"),
+          ),
+        )
+        .limit(1);
+
+      return {
+        conflict: false,
+        progressUpdated,
+        failed: false,
+        hasXpAwarded: !!existingXp,
+      };
     });
 
     if (txResult.conflict) {
@@ -237,19 +255,7 @@ submit.post(
 
     // 8. Dispatch CHALLENGE_SUBMISSION BullMQ job (fire-and-forget)
     // ONLY if XP hasn't been awarded yet for this challenge
-    const [existingXp] = await db
-      .select({ id: userXpTransaction.id })
-      .from(userXpTransaction)
-      .where(
-        and(
-          eq(userXpTransaction.userId, userId),
-          eq(userXpTransaction.challengeSlug, challengeSlug),
-          eq(userXpTransaction.action, "challenge_completed"),
-        ),
-      )
-      .limit(1);
-
-    if (!existingXp) {
+    if (!txResult.hasXpAwarded) {
       challengeSubmissionQueue
         .add("challenge-completed", {
           userId,

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -8,7 +8,11 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { nanoid } from "nanoid";
 import { db } from "../db/index";
-import { userProgress, userSubmission } from "../db/schema/index";
+import {
+  userProgress,
+  userSubmission,
+  userXpTransaction,
+} from "../db/schema/index";
 import { trackChallengeSubmitted } from "../lib/analytics-server";
 import { cacheDelPattern } from "../lib/cache";
 import { redis } from "../lib/redis";
@@ -232,17 +236,32 @@ submit.post(
     }
 
     // 8. Dispatch CHALLENGE_SUBMISSION BullMQ job (fire-and-forget)
-    challengeSubmissionQueue
-      .add("challenge-completed", {
-        userId,
-        challengeSlug,
-        difficulty: detail.difficulty,
-      })
-      .catch((err) => {
-        logger.error("[submit] challenge-submission job dispatch failed", {
-          error: String(err),
+    // ONLY if XP hasn't been awarded yet for this challenge
+    const [existingXp] = await db
+      .select({ id: userXpTransaction.id })
+      .from(userXpTransaction)
+      .where(
+        and(
+          eq(userXpTransaction.userId, userId),
+          eq(userXpTransaction.challengeSlug, challengeSlug),
+          eq(userXpTransaction.action, "challenge_completed"),
+        ),
+      )
+      .limit(1);
+
+    if (!existingXp) {
+      challengeSubmissionQueue
+        .add("challenge-completed", {
+          userId,
+          challengeSlug,
+          difficulty: detail.difficulty,
+        })
+        .catch((err) => {
+          logger.error("[submit] challenge-submission job dispatch failed", {
+            error: String(err),
+          });
         });
-      });
+    }
 
     return c.json({ success: true, objectives });
   },

--- a/packages/api-schemas/src/progress.ts
+++ b/packages/api-schemas/src/progress.ts
@@ -133,6 +133,8 @@ export type ResetChallengeInput = z.infer<typeof ResetChallengeInputSchema>;
 export const ResetChallengeOutputSchema = z.object({
   success: z.boolean(),
   message: z.string(),
+  isReplay: z.boolean().optional(),
+  previousStatus: z.string().optional(),
 });
 export type ResetChallengeOutput = z.infer<typeof ResetChallengeOutputSchema>;
 

--- a/packages/api-schemas/src/progress.ts
+++ b/packages/api-schemas/src/progress.ts
@@ -134,7 +134,7 @@ export const ResetChallengeOutputSchema = z.object({
   success: z.boolean(),
   message: z.string(),
   isReplay: z.boolean().optional(),
-  previousStatus: z.string().optional(),
+  previousStatus: ChallengeStatusSchema.optional(),
 });
 export type ResetChallengeOutput = z.infer<typeof ResetChallengeOutputSchema>;
 


### PR DESCRIPTION
- Update handleReset to conditionally delete XP transactions based on previous status
- Add isReplay and previousStatus to ResetChallengeOutput schema
- Prevent duplicate XP awarding in submit handler for replayed challenges
- Return contextual messages for replay vs abandonment resets