### PR TITLE
fix(analytics): load Umami via head config instead of inline script

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
@@ -31,7 +32,11 @@ export default function Layout({ children }: { children: ReactNode }) {
           {children}
         </RootProvider>
         {umamiUrl && umamiId && (
-          <script defer src={umamiUrl} data-website-id={umamiId} />
+          <Script
+            src={umamiUrl}
+            data-website-id={umamiId}
+            strategy="afterInteractive"
+          />
         )}
       </body>
     </html>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -41,6 +41,9 @@ function NotFoundPage() {
   );
 }
 
+const umamiUrl = import.meta.env.VITE_UMAMI_URL;
+const umamiId = import.meta.env.VITE_UMAMI_ID;
+
 export const Route = createRootRouteWithContext<RouterContext>()({
   notFoundComponent: NotFoundPage,
   head: () => ({
@@ -70,6 +73,16 @@ export const Route = createRootRouteWithContext<RouterContext>()({
         href: "/apple-touch-icon.png",
       },
     ],
+    scripts:
+      umamiUrl && umamiId
+        ? [
+            {
+              src: umamiUrl,
+              defer: true,
+              "data-website-id": umamiId,
+            },
+          ]
+        : [],
   }),
   component: RootComponent,
 });
@@ -114,9 +127,6 @@ function RootComponent() {
 }
 
 function RootDocument({ children }: { children: ReactNode }) {
-  const umamiUrl = import.meta.env.VITE_UMAMI_URL;
-  const umamiId = import.meta.env.VITE_UMAMI_ID;
-
   return (
     <html lang="en">
       <head>
@@ -124,9 +134,6 @@ function RootDocument({ children }: { children: ReactNode }) {
       </head>
       <body>
         {children}
-        {umamiUrl && umamiId && (
-          <script defer src={umamiUrl} data-website-id={umamiId} />
-        )}
         <Scripts />
       </body>
     </html>


### PR DESCRIPTION
Inline `<script>` tags rendered in JSX don't reliably execute under
TanStack Start (SSR + React 19 hydration) or Next.js. Move the Umami
loader to the route's `head.scripts` array in apps/web and to
`next/script` (`afterInteractive`) in apps/docs so the framework
manages the tag and the script actually runs.