### PR TITLE
fix(analytics): pass user id as positional arg to umami.identify

### DIFF
--- a/apps/web/src/components/login-card.tsx
+++ b/apps/web/src/components/login-card.tsx
@@ -1,5 +1,3 @@
-import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
-import { useState } from "react";
 import { Button } from "@kubeasy/ui/button";
 import {
   Card,
@@ -8,6 +6,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@kubeasy/ui/card";
+import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { trackSignInStarted } from "@/lib/analytics";
 import { signInWithSocialProvider } from "@/lib/auth-client";
 
 type SocialProvider = "github" | "google" | "microsoft";
@@ -151,6 +152,7 @@ export function LoginCard({ callbackUrl = "/dashboard" }: LoginCardProps) {
     try {
       setLoadingProvider(provider);
       setAuthResult({ status: "loading", provider });
+      trackSignInStarted(provider);
 
       const data = await signInWithSocialProvider(provider, callbackUrl);
 

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -131,6 +131,16 @@ export function identifyUser(
 }
 
 /**
+ * Track sign-in attempt with a social provider
+ * Fired when the user clicks a provider button on the login page, before
+ * the OAuth redirect.
+ * @param provider - The social provider (e.g., "github", "google", "microsoft")
+ */
+export function trackSignInStarted(provider: string) {
+  safeTrack("signin_started", { provider });
+}
+
+/**
  * Reset analytics state (call on logout)
  * Umami is session-based and doesn't have a direct reset method.
  * Session ends when the browser is closed or after inactivity.

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -64,6 +64,8 @@ export function trackApiTokenCreated() {
   safeTrack("api_token_created");
 }
 
+let pendingIdentifyIntervalId: number | null = null;
+
 /**
  * Identify a user in Umami
  * This should be called after successful authentication
@@ -85,15 +87,18 @@ export function identifyUser(
       // Umami expects the unique ID as the first positional argument; passing
       // it inside the data object would only set session data without
       // assigning a distinctId.
-      if (properties && Object.keys(properties).length > 0) {
-        window.umami?.identify(userId, properties);
-      } else {
-        window.umami?.identify(userId);
-      }
+      window.umami?.identify(userId, properties);
     } catch (error) {
       console.error("[Umami] Failed to identify user", error);
     }
   };
+
+  // Cancel any in-flight poll so the latest call wins and we don't fire
+  // identify multiple times with stale arguments.
+  if (pendingIdentifyIntervalId !== null) {
+    window.clearInterval(pendingIdentifyIntervalId);
+    pendingIdentifyIntervalId = null;
+  }
 
   if (isUmamiReady()) {
     runIdentify();
@@ -104,14 +109,20 @@ export function identifyUser(
   // session resolves on first paint. Poll briefly until it's available.
   const startedAt = Date.now();
   const maxWaitMs = 10_000;
-  const intervalId = window.setInterval(() => {
+  pendingIdentifyIntervalId = window.setInterval(() => {
     if (isUmamiReady()) {
-      window.clearInterval(intervalId);
+      if (pendingIdentifyIntervalId !== null) {
+        window.clearInterval(pendingIdentifyIntervalId);
+        pendingIdentifyIntervalId = null;
+      }
       runIdentify();
       return;
     }
     if (Date.now() - startedAt > maxWaitMs) {
-      window.clearInterval(intervalId);
+      if (pendingIdentifyIntervalId !== null) {
+        window.clearInterval(pendingIdentifyIntervalId);
+        pendingIdentifyIntervalId = null;
+      }
       if (process.env.NODE_ENV === "development") {
         console.info("[Umami] User identification skipped (load timeout)");
       }

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -10,7 +10,10 @@
  */
 interface Umami {
   track: (eventName: string, eventData?: Record<string, unknown>) => void;
-  identify: (properties: Record<string, unknown>) => void;
+  identify: {
+    (uniqueId: string, data?: Record<string, unknown>): void;
+    (data: Record<string, unknown>): void;
+  };
 }
 
 declare global {
@@ -75,21 +78,45 @@ export function identifyUser(
     provider?: string;
   },
 ) {
-  if (!isUmamiReady()) {
-    if (process.env.NODE_ENV === "development") {
-      console.info("[Umami] User identification skipped (not loaded)");
+  if (typeof window === "undefined") return;
+
+  const runIdentify = () => {
+    try {
+      // Umami expects the unique ID as the first positional argument; passing
+      // it inside the data object would only set session data without
+      // assigning a distinctId.
+      if (properties && Object.keys(properties).length > 0) {
+        window.umami?.identify(userId, properties);
+      } else {
+        window.umami?.identify(userId);
+      }
+    } catch (error) {
+      console.error("[Umami] Failed to identify user", error);
     }
+  };
+
+  if (isUmamiReady()) {
+    runIdentify();
     return;
   }
 
-  try {
-    window.umami?.identify({
-      userId,
-      ...properties,
-    });
-  } catch (error) {
-    console.error("[Umami] Failed to identify user", error);
-  }
+  // The Umami script is loaded with `defer`, so it may not be ready when the
+  // session resolves on first paint. Poll briefly until it's available.
+  const startedAt = Date.now();
+  const maxWaitMs = 10_000;
+  const intervalId = window.setInterval(() => {
+    if (isUmamiReady()) {
+      window.clearInterval(intervalId);
+      runIdentify();
+      return;
+    }
+    if (Date.now() - startedAt > maxWaitMs) {
+      window.clearInterval(intervalId);
+      if (process.env.NODE_ENV === "development") {
+        console.info("[Umami] User identification skipped (load timeout)");
+      }
+    }
+  }, 100);
 }
 
 /**


### PR DESCRIPTION
Umami expects the unique id as the first positional argument; passing it
inside the data object only stores session data and leaves distinctId
empty. Also wait for the deferred Umami script to load before calling
identify so the call isn't silently dropped on first paint.