### PR TITLE
perf(docker): add Railway cache mounts for pnpm and turbo

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -10,10 +10,12 @@ RUN turbo prune @kubeasy/api --docker
 FROM builder AS api-builder
 
 COPY --from=api-prepare /app/out/json/ .
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=s/9d68142a-20f6-467b-ae9e-d698d9f004d8-/root/.local/share/pnpm/store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
 
 COPY --from=api-prepare /app/out/full/ .
-RUN turbo run build --filter=@kubeasy/api
+RUN --mount=type=cache,id=s/9d68142a-20f6-467b-ae9e-d698d9f004d8-/app/node_modules/.cache/turbo,target=/app/node_modules/.cache/turbo \
+    turbo run build --filter=@kubeasy/api
 
 FROM api-builder AS api-deploy
 

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -15,7 +15,8 @@ COPY --from=docs-prepare /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 COPY --from=docs-prepare /app/out/full/apps/docs/source.config.ts ./apps/docs/source.config.ts
 
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=s/4971b9dc-4b63-4444-8519-2bcb17fbfbc1-/root/.local/share/pnpm/store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
 
 COPY --from=docs-prepare /app/out/full/ .
 
@@ -24,7 +25,9 @@ ENV NEXT_PUBLIC_UMAMI_URL=$NEXT_PUBLIC_UMAMI_URL
 ARG NEXT_PUBLIC_UMAMI_ID
 ENV NEXT_PUBLIC_UMAMI_ID=$NEXT_PUBLIC_UMAMI_ID
 
-RUN turbo run build --filter=@kubeasy/docs
+RUN --mount=type=cache,id=s/4971b9dc-4b63-4444-8519-2bcb17fbfbc1-/app/node_modules/.cache/turbo,target=/app/node_modules/.cache/turbo \
+    --mount=type=cache,id=s/4971b9dc-4b63-4444-8519-2bcb17fbfbc1-/app/apps/docs/.next/cache,target=/app/apps/docs/.next/cache \
+    turbo run build --filter=@kubeasy/docs
 
 FROM base AS runner
 ENV NODE_ENV=production

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -10,7 +10,8 @@ RUN turbo prune @kubeasy/web --docker
 FROM builder AS web-builder
 
 COPY --from=web-prepare /app/out/json/ .
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=s/de9c1182-9bc5-434a-9692-73c4d557c102-/root/.local/share/pnpm/store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
 
 COPY --from=web-prepare /app/out/full/ .
 
@@ -31,7 +32,8 @@ ENV NOTION_DIRECTORY_DATASOURCE_ID=$NOTION_DIRECTORY_DATASOURCE_ID
 ARG NOTION_PEOPLE_DATASOURCE_ID
 ENV NOTION_PEOPLE_DATASOURCE_ID=$NOTION_PEOPLE_DATASOURCE_ID
 
-RUN turbo run build --filter=@kubeasy/web
+RUN --mount=type=cache,id=s/de9c1182-9bc5-434a-9692-73c4d557c102-/app/node_modules/.cache/turbo,target=/app/node_modules/.cache/turbo \
+    turbo run build --filter=@kubeasy/web
 
 FROM web-builder AS web-deploy
 


### PR DESCRIPTION
Speeds up builds by reusing pnpm store and turbo cache between deploys.
docs also caches .next/cache for incremental Next.js builds.

https://claude.ai/code/session_0178WqrEThj8ThfrNJ6BkQKR