### PR TITLE
fix(seo): fix sitemap index, add dynamic head() tags, clean footer, static hero

### DIFF
--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -5,7 +5,10 @@ import { source } from "@/lib/source";
 export const revalidate = false;
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const url = (path: string): string => new URL(path, baseUrl).toString();
+  // Use string concatenation so absolute paths like "/user/cli-reference" don't
+  // override the "/docs" segment of baseUrl (new URL(absPath, base) strips base path).
+  const base = baseUrl.href.replace(/\/$/, "");
+  const url = (path: string): string => `${base}${path}`;
   const items = source
     .getPages()
     .filter((page) => page.data.type !== "openapi")
@@ -23,11 +26,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: url("/showcase"),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: url("/docs"),
       changeFrequency: "monthly",
       priority: 0.8,
     },

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -29,6 +29,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.8,
     },
-    ...items.filter((v) => v !== undefined),
+    ...items,
   ];
 }

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -35,9 +35,7 @@ export function Footer() {
               </li>
               <li>
                 <a
-                  href={siteConfig.links.docs}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href="/docs"
                   className="hover:text-primary transition-colors"
                 >
                   Documentation
@@ -71,17 +69,7 @@ export function Footer() {
               </li>
               <li>
                 <a
-                  href={siteConfig.links.github}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-primary transition-colors"
-                >
-                  Discord
-                </a>
-              </li>
-              <li>
-                <a
-                  href={siteConfig.links.github}
+                  href="https://github.com/kubeasy-dev/challenges/blob/main/CONTRIBUTING.md"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:text-primary transition-colors"

--- a/apps/web/src/components/hero-section.tsx
+++ b/apps/web/src/components/hero-section.tsx
@@ -1,6 +1,5 @@
 import { ArrowRight, Terminal } from "lucide-react";
 import { lazy, Suspense } from "react";
-import { TypewriterText } from "./typewriter-text";
 
 const InteractiveTerminal = lazy(() => import("./interactive-terminal"));
 
@@ -16,13 +15,7 @@ export function HeroSection() {
             </div>
 
             <h1 className="text-7xl font-black leading-[1.1] text-balance">
-              <TypewriterText
-                texts={["Build it.", "Fix it.", "Migrate it."]}
-                typingSpeed={100}
-                deletingSpeed={80}
-              />
-              <br />
-              <span className="text-primary">Learn Kubernetes.</span>
+              Learn Kubernetes by solving real broken clusters.
             </h1>
 
             <p className="text-xl md:text-2xl font-black">

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -29,6 +29,6 @@ export const siteConfig = {
   },
   github: {
     owner: githubOwner,
-    repo: "website",
+    repo: "monorepo",
   },
 };

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute("/blog/$slug")({
 
     const pageTitle = `${post.title} | Kubeasy Blog`;
     const description = (post.description ?? "").slice(0, 155);
-    const ogDescription = (post.description ?? description).slice(0, 200);
+    const ogDescription = (post.description ?? "").slice(0, 200);
     const pageUrl = `${siteConfig.url}/blog/${params.slug}`;
 
     const jsonLd = {

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -4,6 +4,7 @@ import { Calendar, ChevronLeft, Clock } from "lucide-react";
 import { lazy, Suspense } from "react";
 import { AuthorCard } from "@/components/author-card";
 import { RelatedPosts } from "@/components/related-posts";
+import { siteConfig } from "@/lib/constants";
 import type { NotionBlock, RichTextItem } from "@/lib/notion";
 import { blogPostDetailOptions } from "@/lib/query-options";
 
@@ -21,6 +22,55 @@ export const Route = createFileRoute("/blog/$slug")({
       blogPostDetailOptions(params.slug),
     );
     if (!data) throw notFound();
+    return data;
+  },
+  head: ({ loaderData, params }) => {
+    if (!loaderData) return {};
+    const { post } = loaderData;
+
+    const pageTitle = `${post.title} | Kubeasy Blog`;
+    const description = (post.description ?? "").slice(0, 155);
+    const ogDescription = (post.description ?? description).slice(0, 200);
+    const pageUrl = `${siteConfig.url}/blog/${params.slug}`;
+
+    const jsonLd = {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      headline: post.title,
+      description: post.description ?? undefined,
+      url: pageUrl,
+      datePublished: post.publishedAt,
+      author: {
+        "@type": "Person",
+        name: post.author.name,
+      },
+      publisher: {
+        "@type": "Organization",
+        name: "Kubeasy",
+        url: siteConfig.url,
+      },
+      inLanguage: "en",
+    };
+
+    return {
+      meta: [
+        { title: pageTitle },
+        ...(description ? [{ name: "description", content: description }] : []),
+        { property: "og:type", content: "article" },
+        { property: "og:title", content: post.title },
+        ...(ogDescription
+          ? [{ property: "og:description", content: ogDescription }]
+          : []),
+        { property: "og:url", content: pageUrl },
+        { property: "og:site_name", content: "Kubeasy" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:site", content: "@kubeasy_dev" },
+      ],
+      links: [{ rel: "canonical", href: pageUrl }],
+      scripts: [
+        { type: "application/ld+json", children: JSON.stringify(jsonLd) },
+      ],
+    };
   },
   component: BlogArticlePage,
 });

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -13,6 +13,29 @@ export const Route = createFileRoute("/blog/")({
       "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
     Link: `<${siteConfig.url}/blog>; rel="alternate"; type="text/markdown"`,
   }),
+  head: () => ({
+    meta: [
+      { title: "Kubeasy Blog — Kubernetes Guides & Tutorials" },
+      {
+        name: "description",
+        content:
+          "Deep dives into Kubernetes, DevOps practices, and cloud-native development. Learn from real-world experiences and best practices.",
+      },
+      { property: "og:type", content: "website" },
+      {
+        property: "og:title",
+        content: "Kubeasy Blog — Kubernetes Guides & Tutorials",
+      },
+      {
+        property: "og:description",
+        content:
+          "Deep dives into Kubernetes, DevOps practices, and cloud-native development. Learn from real-world experiences and best practices.",
+      },
+      { property: "og:url", content: `${siteConfig.url}/blog` },
+      { property: "og:site_name", content: "Kubeasy" },
+    ],
+    links: [{ rel: "canonical", href: `${siteConfig.url}/blog` }],
+  }),
   loader: async ({ context: { queryClient } }) => {
     await queryClient.ensureQueryData(blogListOptions());
   },

--- a/apps/web/src/routes/challenges/$slug.tsx
+++ b/apps/web/src/routes/challenges/$slug.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft, Clock } from "lucide-react";
 import { useRequest } from "nitro/context";
 import { ChallengeMission } from "@/components/challenge-mission";
 import { DifficultyBadge } from "@/components/difficulty-badge";
+import { siteConfig } from "@/lib/constants";
 import {
   challengeDetailOptions,
   challengeObjectivesOptions,
@@ -29,12 +30,67 @@ export const Route = createFileRoute("/challenges/$slug")({
       log?.info("page.load");
     }
     // SSR prefetch: base challenge data (WEB-03)
-    await Promise.all([
+    const [detail] = await Promise.all([
       queryClient.ensureQueryData(challengeDetailOptions(params.slug)),
       queryClient.ensureQueryData(challengeObjectivesOptions(params.slug)),
     ]);
     // NOTE: Do NOT prefetch latestValidation or challengeStatus here
     // Those are client-only (WEB-05 hybrid rendering)
+    return { detail };
+  },
+  head: ({ loaderData, params }) => {
+    const challenge = loaderData?.detail?.challenge;
+    if (!challenge) return {};
+
+    const pageTitle = `${challenge.title} — Kubernetes Hands-On Challenge | Kubeasy`;
+    const description = challenge.description.slice(0, 155);
+    const ogDescription = challenge.description.slice(0, 200);
+    const pageUrl = `${siteConfig.url}/challenges/${params.slug}`;
+
+    const jsonLd = {
+      "@context": "https://schema.org",
+      "@type": "LearningResource",
+      name: challenge.title,
+      description: challenge.description,
+      url: pageUrl,
+      learningResourceType: "Exercise",
+      educationalLevel: challenge.difficulty,
+      about: "Kubernetes",
+      teaches: challenge.theme,
+      timeRequired: `PT${challenge.estimatedTime}M`,
+      isAccessibleForFree: true,
+      inLanguage: "en",
+      provider: {
+        "@type": "Organization",
+        name: "Kubeasy",
+        url: siteConfig.url,
+      },
+    };
+
+    return {
+      meta: [
+        { title: pageTitle },
+        { name: "description", content: description },
+        { property: "og:type", content: "article" },
+        {
+          property: "og:title",
+          content: `${challenge.title} — Kubernetes Hands-On Challenge`,
+        },
+        { property: "og:description", content: ogDescription },
+        { property: "og:url", content: pageUrl },
+        {
+          property: "og:image",
+          content: `${siteConfig.url}/og/challenges/${params.slug}.png`,
+        },
+        { property: "og:site_name", content: "Kubeasy" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:site", content: "@kubeasy_dev" },
+      ],
+      links: [{ rel: "canonical", href: pageUrl }],
+      scripts: [
+        { type: "application/ld+json", children: JSON.stringify(jsonLd) },
+      ],
+    };
   },
   component: ChallengeDetailPage,
 });

--- a/apps/web/src/routes/challenges/index.tsx
+++ b/apps/web/src/routes/challenges/index.tsx
@@ -28,6 +28,29 @@ export const Route = createFileRoute("/challenges/")({
       "public, max-age=600, s-maxage=600, stale-while-revalidate=3600",
     Link: `<${siteConfig.url}/challenges>; rel="alternate"; type="text/markdown"`,
   }),
+  head: () => ({
+    meta: [
+      { title: "Kubernetes Challenges — Learn by Doing | Kubeasy" },
+      {
+        name: "description",
+        content:
+          "Master Kubernetes through hands-on challenges. Practice with real broken clusters — from pod failures to config errors and deprecated APIs. Free and open source.",
+      },
+      { property: "og:type", content: "website" },
+      {
+        property: "og:title",
+        content: "Kubernetes Challenges — Learn by Doing | Kubeasy",
+      },
+      {
+        property: "og:description",
+        content:
+          "Master Kubernetes through hands-on challenges. Practice with real broken clusters — from pod failures to config errors and deprecated APIs.",
+      },
+      { property: "og:url", content: `${siteConfig.url}/challenges` },
+      { property: "og:site_name", content: "Kubeasy" },
+    ],
+    links: [{ rel: "canonical", href: `${siteConfig.url}/challenges` }],
+  }),
   loader: async ({ context: { queryClient } }) => {
     if (import.meta.env.SSR) {
       // biome-ignore lint/correctness/useHookAtTopLevel: useRequest is a Nitro hook, not a React hook

--- a/apps/web/src/routes/sitemap-main[.]xml.ts
+++ b/apps/web/src/routes/sitemap-main[.]xml.ts
@@ -1,0 +1,91 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { siteConfig } from "@/lib/constants";
+import { getBlogPosts } from "@/lib/notion";
+import { rpc, unwrap } from "@/lib/rpc";
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function url(
+  loc: string,
+  opts?: { lastmod?: string; changefreq?: string; priority?: string },
+): string {
+  return [
+    "  <url>",
+    `    <loc>${escapeXml(loc)}</loc>`,
+    opts?.lastmod ? `    <lastmod>${opts.lastmod}</lastmod>` : "",
+    opts?.changefreq ? `    <changefreq>${opts.changefreq}</changefreq>` : "",
+    opts?.priority ? `    <priority>${opts.priority}</priority>` : "",
+    "  </url>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function toDate(d: Date | string): string {
+  return new Date(d).toISOString().split("T")[0];
+}
+
+export const Route = createFileRoute("/sitemap-main.xml")({
+  server: {
+    handlers: {
+      GET: async () => {
+        const base = siteConfig.url;
+
+        const staticUrls = [
+          url(`${base}/`, { changefreq: "daily", priority: "1.0" }),
+          url(`${base}/challenges`, { changefreq: "daily", priority: "0.9" }),
+          url(`${base}/blog`, { changefreq: "weekly", priority: "0.8" }),
+        ];
+
+        const [posts, challengeResult] = await Promise.allSettled([
+          getBlogPosts(),
+          unwrap(rpc.challenges.$get({ query: {} })),
+        ]);
+
+        const blogUrls =
+          posts.status === "fulfilled"
+            ? posts.value.map((p) =>
+                url(`${base}/blog/${p.slug}`, {
+                  lastmod: toDate(p.updatedAt),
+                  changefreq: "monthly",
+                  priority: "0.7",
+                }),
+              )
+            : [];
+
+        const challengeUrls =
+          challengeResult.status === "fulfilled"
+            ? challengeResult.value.challenges.map((c) =>
+                url(`${base}/challenges/${c.slug}`, {
+                  changefreq: "weekly",
+                  priority: "0.8",
+                }),
+              )
+            : [];
+
+        const sitemap = [
+          '<?xml version="1.0" encoding="UTF-8"?>',
+          '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+          ...staticUrls,
+          ...challengeUrls,
+          ...blogUrls,
+          "</urlset>",
+        ].join("\n");
+
+        return new Response(sitemap, {
+          headers: {
+            "Content-Type": "application/xml; charset=utf-8",
+            "Cache-Control":
+              "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -1,84 +1,24 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { siteConfig } from "@/lib/constants";
-import { getBlogPosts } from "@/lib/notion";
-import { rpc, unwrap } from "@/lib/rpc";
-
-function escapeXml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function url(
-  loc: string,
-  opts?: { lastmod?: string; changefreq?: string; priority?: string },
-): string {
-  return [
-    "  <url>",
-    `    <loc>${escapeXml(loc)}</loc>`,
-    opts?.lastmod ? `    <lastmod>${opts.lastmod}</lastmod>` : "",
-    opts?.changefreq ? `    <changefreq>${opts.changefreq}</changefreq>` : "",
-    opts?.priority ? `    <priority>${opts.priority}</priority>` : "",
-    "  </url>",
-  ]
-    .filter(Boolean)
-    .join("\n");
-}
-
-function toDate(d: Date | string): string {
-  return new Date(d).toISOString().split("T")[0];
-}
 
 export const Route = createFileRoute("/sitemap.xml")({
   server: {
     handlers: {
-      GET: async () => {
+      GET: () => {
         const base = siteConfig.url;
-
-        const staticUrls = [
-          url(`${base}/`, { changefreq: "daily", priority: "1.0" }),
-          url(`${base}/challenges`, { changefreq: "daily", priority: "0.9" }),
-          url(`${base}/blog`, { changefreq: "weekly", priority: "0.8" }),
-        ];
-
-        const [posts, challengeResult] = await Promise.allSettled([
-          getBlogPosts(),
-          unwrap(rpc.challenges.$get({ query: {} })),
-        ]);
-
-        const blogUrls =
-          posts.status === "fulfilled"
-            ? posts.value.map((p) =>
-                url(`${base}/blog/${p.slug}`, {
-                  lastmod: toDate(p.updatedAt),
-                  changefreq: "monthly",
-                  priority: "0.7",
-                }),
-              )
-            : [];
-
-        const challengeUrls =
-          challengeResult.status === "fulfilled"
-            ? challengeResult.value.challenges.map((c) =>
-                url(`${base}/challenges/${c.slug}`, {
-                  changefreq: "weekly",
-                  priority: "0.8",
-                }),
-              )
-            : [];
-
-        const sitemap = [
+        const index = [
           '<?xml version="1.0" encoding="UTF-8"?>',
-          '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-          ...staticUrls,
-          ...challengeUrls,
-          ...blogUrls,
-          "</urlset>",
+          '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+          "  <sitemap>",
+          `    <loc>${base}/sitemap-main.xml</loc>`,
+          "  </sitemap>",
+          "  <sitemap>",
+          `    <loc>${base}/docs/sitemap.xml</loc>`,
+          "  </sitemap>",
+          "</sitemapindex>",
         ].join("\n");
 
-        return new Response(sitemap, {
+        return new Response(index, {
           headers: {
             "Content-Type": "application/xml; charset=utf-8",
             "Cache-Control":


### PR DESCRIPTION
Task 1 — Docs sitemap: fix URL prefix bug where new URL(absPath, base) was
stripping the /docs segment. Switch to string concatenation so all docs URLs
correctly start with https://kubeasy.dev/docs/. Convert sitemap.xml into a
sitemapindex referencing sitemap-main.xml (previous content) and
/docs/sitemap.xml. Remove the now-redundant /docs static entry from the docs
sitemap.

Task 2 — Dynamic <head>: add head() to challenges/$slug (title, description,
canonical, OG, twitter, LearningResource JSON-LD), challenges/index (static
OG), blog/index (static OG), and blog/$slug (title, description, canonical,
OG, Article JSON-LD). Loaders now return data so head() can access it via
loaderData.

Task 3 — Footer: change Documentation href from docs.kubeasy.dev to /docs
(internal link, no redirect hop, no target=_blank). Remove Discord entry that
pointed to the wrong URL. Fix Contribute href to the CONTRIBUTING.md file.

Task 5 — Hero: replace the typewriter animation (Build it./Fix it./Migrate
it.) with a single static h1 "Learn Kubernetes by solving real broken
clusters." for better LCP and consistent Google crawl snapshot.

https://claude.ai/code/session_018FgEi3ub9hpdHdz88pBcnL