### PR TITLE
fix: remove external link attributes from internal /docs links

### DIFF
--- a/apps/web/src/components/cta-section.tsx
+++ b/apps/web/src/components/cta-section.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@kubeasy/ui/button";
 import { ArrowRight } from "lucide-react";
-import { siteConfig } from "@/lib/constants";
 
 export function CTASection() {
   return (
@@ -32,13 +31,7 @@ export function CTASection() {
                 className="text-base font-bold bg-secondary text-foreground hover:bg-secondary/90 neo-border-thick neo-shadow-lg border-foreground"
                 asChild
               >
-                <a
-                  href={siteConfig.links.docs}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  View Documentation
-                </a>
+                <a href="/docs">View Documentation</a>
               </Button>
             </div>
           </div>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -47,8 +47,6 @@ export function Header() {
               <a
                 key={href}
                 href={href}
-                target="_blank"
-                rel="noopener noreferrer"
                 className="inline-flex h-9 w-max items-center justify-center rounded-lg bg-background px-4 py-2 text-base font-bold transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
               >
                 {label}


### PR DESCRIPTION
- CTA "View Documentation" button: replace docs.kubeasy.dev href with /docs and drop target="_blank"/rel
- Header "Documentation" nav link: remove target="_blank" and rel="noopener noreferrer"