### PR TITLE
feat: challenge completion modal with SSE celebration events

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,11 @@
   "mcpServers": {
     "postgres": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-postgres", "${DATABASE_URL}"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "postgresql://kubeasy:kubeasy@localhost:5432/kubeasy"
+      ]
     },
     "shadcn": {
       "command": "npx",

--- a/apps/api/drizzle/0005_mature_goblin_queen.sql
+++ b/apps/api/drizzle/0005_mature_goblin_queen.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "user_xp_transaction_unique_user_challenge_action_idx" ON "user_xp_transaction" USING btree ("user_id","challenge_slug","action") WHERE "user_xp_transaction"."challenge_slug" IS NOT NULL;

--- a/apps/api/drizzle/meta/0005_snapshot.json
+++ b/apps/api/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1347 @@
+{
+  "id": "9b054ed3-4415-4038-8348-1cd307bbdba9",
+  "prevId": "b0e88f3b-ee76-4b50-9ef4-6248b1aa05a3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_contact_id": {
+          "name": "resend_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_metadata": {
+      "name": "challenge_metadata",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "of_the_week": {
+          "name": "of_the_week",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "starter_friendly": {
+          "name": "starter_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_metadata_available_idx": {
+          "name": "challenge_metadata_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_progress": {
+      "name": "user_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_slug": {
+          "name": "challenge_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "challenge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_progress_user_challenge_unique_idx": {
+          "name": "user_progress_user_challenge_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_user_status_challenge_idx": {
+          "name": "user_progress_user_status_challenge_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_challenge_status_idx": {
+          "name": "user_progress_challenge_status_idx",
+          "columns": [
+            {
+              "expression": "challenge_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_progress_user_id_user_id_fk": {
+          "name": "user_progress_user_id_user_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_submission": {
+      "name": "user_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_slug": {
+          "name": "challenge_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_events": {
+          "name": "audit_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_submission_user_challenge_attempt_idx": {
+          "name": "user_submission_user_challenge_attempt_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_submission_user_challenge_idx": {
+          "name": "user_submission_user_challenge_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_submission_user_id_user_id_fk": {
+          "name": "user_submission_user_id_user_id_fk",
+          "tableFrom": "user_submission",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_xp": {
+      "name": "user_xp",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_xp_total_xp_idx": {
+          "name": "user_xp_total_xp_idx",
+          "columns": [
+            {
+              "expression": "total_xp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_xp_user_id_user_id_fk": {
+          "name": "user_xp_user_id_user_id_fk",
+          "tableFrom": "user_xp",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_xp_transaction": {
+      "name": "user_xp_transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "xp_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp_amount": {
+          "name": "xp_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_slug": {
+          "name": "challenge_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_xp_transaction_user_id_idx": {
+          "name": "user_xp_transaction_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_xp_transaction_user_action_idx": {
+          "name": "user_xp_transaction_user_action_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_xp_transaction_unique_user_challenge_action_idx": {
+          "name": "user_xp_transaction_unique_user_challenge_action_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_xp_transaction\".\"challenge_slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_xp_transaction_user_id_user_id_fk": {
+          "name": "user_xp_transaction_user_id_user_id_fk",
+          "tableFrom": "user_xp_transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_topic": {
+      "name": "email_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "email_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "resend_topic_id": {
+          "name": "resend_topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_opt_in": {
+          "name": "default_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_topic_resend_topic_id_unique": {
+          "name": "email_topic_resend_topic_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding": {
+      "name": "user_onboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_authenticated": {
+          "name": "cli_authenticated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cluster_initialized": {
+          "name": "cluster_initialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_onboarding_user_id_idx": {
+          "name": "user_onboarding_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_user_id_user_id_fk": {
+          "name": "user_onboarding_user_id_user_id_fk",
+          "tableFrom": "user_onboarding",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_onboarding_user_id_unique": {
+          "name": "user_onboarding_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.challenge_status": {
+      "name": "challenge_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed"
+      ]
+    },
+    "public.xp_action": {
+      "name": "xp_action",
+      "schema": "public",
+      "values": [
+        "challenge_completed",
+        "daily_streak",
+        "first_challenge",
+        "milestone_reached",
+        "bonus"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777053052855,
       "tag": "0004_previous_kingpin",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1779093668782,
+      "tag": "0005_mature_goblin_queen",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2243,6 +2243,42 @@
         }
       }
     },
+    "/api/sse/challenge/{slug}": {
+      "get": {
+        "operationId": "getApiSseChallengeBySlug",
+        "tags": [
+          "SSE"
+        ],
+        "summary": "Per-challenge SSE channel (challenge-completed events)",
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "slug",
+            "required": true
+          }
+        ]
+      }
+    },
     "/api/sse/invalidate-cache": {
       "get": {
         "operationId": "getApiSseInvalidateCache",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -905,7 +905,9 @@
             "in": "path",
             "name": "slug",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 200,
+              "pattern": "^[a-z0-9-]+$"
             },
             "required": true
           }
@@ -967,7 +969,9 @@
             "in": "path",
             "name": "slug",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 200,
+              "pattern": "^[a-z0-9-]+$"
             },
             "required": true
           }
@@ -1033,7 +1037,9 @@
             "in": "path",
             "name": "slug",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 200,
+              "pattern": "^[a-z0-9-]+$"
             },
             "required": true
           }
@@ -1097,7 +1103,9 @@
             "in": "path",
             "name": "slug",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 200,
+              "pattern": "^[a-z0-9-]+$"
             },
             "required": true
           }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2269,11 +2269,13 @@
         },
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
             "in": "path",
             "name": "slug",
+            "schema": {
+              "type": "string",
+              "maxLength": 200,
+              "pattern": "^[a-z0-9-]+$"
+            },
             "required": true
           }
         ]

--- a/apps/api/src/db/schema/challenge.ts
+++ b/apps/api/src/db/schema/challenge.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -117,5 +118,8 @@ export const userXpTransaction = pgTable(
   (table) => [
     index("user_xp_transaction_user_id_idx").on(table.userId),
     index("user_xp_transaction_user_action_idx").on(table.userId, table.action),
+    uniqueIndex("user_xp_transaction_unique_user_challenge_action_idx")
+      .on(table.userId, table.challengeSlug, table.action)
+      .where(sql`${table.challengeSlug} IS NOT NULL`),
   ],
 );

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -24,7 +24,12 @@ import { redis } from "../lib/redis";
 import { getChallenge, listChallenges } from "../lib/registry";
 import { type AppEnv, requireAuth } from "../middleware/session";
 
-const slugParam = z.object({ slug: z.string() });
+const slugParam = z.object({
+  slug: z
+    .string()
+    .max(200)
+    .regex(/^[a-z0-9-]+$/, "Invalid slug format"),
+});
 
 const getStatusOpenApi = {
   tags: ["CLI", "Progress"] as string[],

--- a/apps/api/src/routes/progress.ts
+++ b/apps/api/src/routes/progress.ts
@@ -20,6 +20,7 @@ import {
 import { trackChallengeStarted } from "../lib/analytics-server";
 import { cacheDel, cacheDelPattern, cached, cacheKey, TTL } from "../lib/cache";
 import { sessionOrBearerSecurity } from "../lib/openapi-shared";
+import { redis } from "../lib/redis";
 import { getChallenge, listChallenges } from "../lib/registry";
 import { type AppEnv, requireAuth } from "../middleware/session";
 
@@ -268,6 +269,12 @@ export const progress = new Hono<AppEnv>()
             .update(userProgress)
             .set({ status: "in_progress", startedAt: now })
             .where(eq(userProgress.id, existingProgress.id));
+          redis
+            .publish(
+              `invalidate-cache:${userId}`,
+              JSON.stringify({ queryKey: ["progress", "status", slug] }),
+            )
+            .catch(() => {});
         }
         return c.json({
           status: "in_progress" as const,
@@ -290,6 +297,13 @@ export const progress = new Hono<AppEnv>()
           error: String(err),
         });
       });
+
+      redis
+        .publish(
+          `invalidate-cache:${userId}`,
+          JSON.stringify({ queryKey: ["progress", "status", slug] }),
+        )
+        .catch(() => {});
 
       Promise.all([
         cacheDel(cacheKey(`u:${userId}:progress:status`, { slug })),

--- a/apps/api/src/routes/sse.ts
+++ b/apps/api/src/routes/sse.ts
@@ -6,6 +6,74 @@ import { sessionSecurity } from "../lib/openapi-shared";
 import { redisConfig } from "../lib/redis";
 import { type AppEnv, requireAuth } from "../middleware/session";
 
+type SSEStream = Parameters<Parameters<typeof streamSSE>[1]>[0];
+
+/**
+ * Subscribe to a Redis channel and forward messages as SSE events.
+ * onMessage transforms a raw Redis message into an SSE event object (or null to skip).
+ */
+function createRedisSSEHandler(
+  channel: string,
+  onMessage: (
+    message: string,
+  ) =>
+    | { event: string; data: string }
+    | null
+    | Promise<{ event: string; data: string } | null>,
+) {
+  return async (
+    stream: SSEStream,
+    log: { error: (msg: string, ctx: Record<string, unknown>) => void },
+  ) => {
+    const subscriber = new Redis(redisConfig);
+    let aborted = false;
+
+    stream.onAbort(async () => {
+      aborted = true;
+      try {
+        await subscriber.unsubscribe(channel);
+        await subscriber.quit();
+      } catch (err) {
+        log.error("SSE cleanup error", { channel, error: String(err) });
+      }
+    });
+
+    subscriber.on("message", async (_ch: string, message: string) => {
+      const sseEvent = await onMessage(message);
+      if (sseEvent) {
+        await stream.writeSSE(sseEvent);
+      }
+    });
+
+    await subscriber.subscribe(channel);
+
+    while (!aborted) {
+      await stream.writeSSE({ data: "", event: "heartbeat" });
+      await stream.sleep(30_000);
+    }
+  };
+}
+
+function parseDynamicEvent(
+  message: string,
+): { event: string; data: string } | null {
+  try {
+    const parsed = JSON.parse(message) as { event?: string; data?: unknown };
+    if (parsed.event) {
+      return {
+        event: parsed.event,
+        data:
+          typeof parsed.data === "string"
+            ? parsed.data
+            : JSON.stringify(parsed.data),
+      };
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
 export const sse = new Hono<AppEnv>()
   .get(
     "/challenge/:slug",
@@ -25,52 +93,8 @@ export const sse = new Hono<AppEnv>()
       const user = c.get("user");
       const slug = c.req.param("slug");
       const channel = `challenge:${user.id}:${slug}`;
-
-      return streamSSE(c, async (stream) => {
-        const subscriber = new Redis(redisConfig);
-        let aborted = false;
-
-        stream.onAbort(async () => {
-          aborted = true;
-          try {
-            await subscriber.unsubscribe(channel);
-            await subscriber.quit();
-          } catch (err) {
-            c.get("log").error("SSE cleanup error", {
-              channel,
-              error: String(err),
-            });
-          }
-        });
-
-        subscriber.on("message", async (_ch: string, message: string) => {
-          try {
-            const parsed = JSON.parse(message) as {
-              event?: string;
-              data?: unknown;
-            };
-            if (parsed.event) {
-              await stream.writeSSE({
-                event: parsed.event,
-                data:
-                  typeof parsed.data === "string"
-                    ? parsed.data
-                    : JSON.stringify(parsed.data),
-              });
-              return;
-            }
-          } catch {
-            // ignore malformed messages
-          }
-        });
-
-        await subscriber.subscribe(channel);
-
-        while (!aborted) {
-          await stream.writeSSE({ data: "", event: "heartbeat" });
-          await stream.sleep(30_000);
-        }
-      });
+      const handler = createRedisSSEHandler(channel, parseDynamicEvent);
+      return streamSSE(c, (stream) => handler(stream, c.get("log")));
     },
   )
   .get(
@@ -90,53 +114,13 @@ export const sse = new Hono<AppEnv>()
     async (c) => {
       const user = c.get("user");
       const channel = `invalidate-cache:${user.id}`;
-
-      return streamSSE(c, async (stream) => {
-        const subscriber = new Redis(redisConfig);
-        let aborted = false;
-
-        stream.onAbort(async () => {
-          aborted = true;
-          try {
-            await subscriber.unsubscribe(channel);
-            await subscriber.quit();
-          } catch (err) {
-            c.get("log").error("SSE cleanup error", {
-              channel,
-              error: String(err),
-            });
-          }
-        });
-
-        subscriber.on("message", async (_ch: string, message: string) => {
-          try {
-            const parsed = JSON.parse(message) as {
-              event?: string;
-              data?: unknown;
-            };
-            if (parsed.event) {
-              await stream.writeSSE({
-                event: parsed.event,
-                data:
-                  typeof parsed.data === "string"
-                    ? parsed.data
-                    : JSON.stringify(parsed.data),
-              });
-              return;
-            }
-          } catch {
-            // fall through to legacy path
-          }
-          // Legacy format: publish({ queryKey: [...] }) from xp-award.worker
-          await stream.writeSSE({ data: message, event: "invalidate-cache" });
-        });
-
-        await subscriber.subscribe(channel);
-
-        while (!aborted) {
-          await stream.writeSSE({ data: "", event: "heartbeat" });
-          await stream.sleep(30_000);
-        }
+      const handler = createRedisSSEHandler(channel, (message) => {
+        // Try new dynamic event format first
+        const dynamic = parseDynamicEvent(message);
+        if (dynamic) return dynamic;
+        // Legacy format: raw JSON published by older xp-award.worker
+        return { event: "invalidate-cache", data: message };
       });
+      return streamSSE(c, (stream) => handler(stream, c.get("log")));
     },
   );

--- a/apps/api/src/routes/sse.ts
+++ b/apps/api/src/routes/sse.ts
@@ -1,10 +1,20 @@
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { describeRoute } from "hono-openapi";
+import { describeRoute, validator } from "hono-openapi";
 import { Redis } from "ioredis";
+import { z } from "zod";
 import { sessionSecurity } from "../lib/openapi-shared";
-import { redisConfig } from "../lib/redis";
+import { redis, redisConfig } from "../lib/redis";
+import { slidingWindowRateLimit } from "../middleware/rate-limit";
 import { type AppEnv, requireAuth } from "../middleware/session";
+
+const slugParam = z.object({ slug: z.string().max(200) });
+
+const sseRateLimit = slidingWindowRateLimit(redis, {
+  windowMs: 60_000,
+  max: 20,
+  keyFn: (c) => `sse:${c.get("user")?.id}`,
+});
 
 type SSEStream = Parameters<Parameters<typeof streamSSE>[1]>[0];
 
@@ -32,7 +42,7 @@ function createRedisSSEHandler(
       aborted = true;
       try {
         await subscriber.unsubscribe(channel);
-        await subscriber.quit();
+        subscriber.disconnect();
       } catch (err) {
         log.error("SSE cleanup error", { channel, error: String(err) });
       }
@@ -89,9 +99,11 @@ export const sse = new Hono<AppEnv>()
       },
     }),
     requireAuth,
+    sseRateLimit,
+    validator("param", slugParam),
     async (c) => {
       const user = c.get("user");
-      const slug = c.req.param("slug");
+      const { slug } = c.req.valid("param");
       const channel = `challenge:${user.id}:${slug}`;
       const handler = createRedisSSEHandler(channel, parseDynamicEvent);
       return streamSSE(c, (stream) => handler(stream, c.get("log")));
@@ -111,6 +123,7 @@ export const sse = new Hono<AppEnv>()
       },
     }),
     requireAuth,
+    sseRateLimit,
     async (c) => {
       const user = c.get("user");
       const channel = `invalidate-cache:${user.id}`;

--- a/apps/api/src/routes/sse.ts
+++ b/apps/api/src/routes/sse.ts
@@ -8,12 +8,23 @@ import { redis, redisConfig } from "../lib/redis";
 import { slidingWindowRateLimit } from "../middleware/rate-limit";
 import { type AppEnv, requireAuth } from "../middleware/session";
 
-const slugParam = z.object({ slug: z.string().max(200) });
+const slugParam = z.object({
+  slug: z
+    .string()
+    .max(200)
+    .regex(/^[a-z0-9-]+$/, "Invalid slug format"),
+});
+
+const ALLOWED_SSE_EVENTS = new Set(["challenge-completed", "invalidate-cache"]);
 
 const sseRateLimit = slidingWindowRateLimit(redis, {
   windowMs: 60_000,
   max: 20,
-  keyFn: (c) => `sse:${c.get("user")?.id}`,
+  keyFn: (c) => {
+    const user = c.get("user");
+    if (!user) throw new Error("sseRateLimit used outside requireAuth");
+    return `sse:${user.id}`;
+  },
 });
 
 type SSEStream = Parameters<Parameters<typeof streamSSE>[1]>[0];
@@ -69,7 +80,7 @@ function parseDynamicEvent(
 ): { event: string; data: string } | null {
   try {
     const parsed = JSON.parse(message) as { event?: string; data?: unknown };
-    if (parsed.event) {
+    if (parsed.event && ALLOWED_SSE_EVENTS.has(parsed.event)) {
       return {
         event: parsed.event,
         data:

--- a/apps/api/src/routes/sse.ts
+++ b/apps/api/src/routes/sse.ts
@@ -53,9 +53,10 @@ function createRedisSSEHandler(
       aborted = true;
       try {
         await subscriber.unsubscribe(channel);
-        subscriber.disconnect();
       } catch (err) {
         log.error("SSE cleanup error", { channel, error: String(err) });
+      } finally {
+        subscriber.disconnect();
       }
     });
 
@@ -143,6 +144,7 @@ export const sse = new Hono<AppEnv>()
         const dynamic = parseDynamicEvent(message);
         if (dynamic) return dynamic;
         // Legacy format: raw JSON published by older xp-award.worker
+        if (message.length > 4096) return null;
         return { event: "invalidate-cache", data: message };
       });
       return streamSSE(c, (stream) => handler(stream, c.get("log")));

--- a/apps/api/src/routes/sse.ts
+++ b/apps/api/src/routes/sse.ts
@@ -6,54 +6,137 @@ import { sessionSecurity } from "../lib/openapi-shared";
 import { redisConfig } from "../lib/redis";
 import { type AppEnv, requireAuth } from "../middleware/session";
 
-export const sse = new Hono<AppEnv>().get(
-  "/invalidate-cache",
-  describeRoute({
-    tags: ["SSE"],
-    summary: "Generic cache-invalidation SSE channel",
-    security: sessionSecurity,
-    responses: {
-      200: {
-        description: "SSE stream",
-        content: { "text/event-stream": { schema: { type: "string" } } },
+export const sse = new Hono<AppEnv>()
+  .get(
+    "/challenge/:slug",
+    describeRoute({
+      tags: ["SSE"],
+      summary: "Per-challenge SSE channel (challenge-completed events)",
+      security: sessionSecurity,
+      responses: {
+        200: {
+          description: "SSE stream",
+          content: { "text/event-stream": { schema: { type: "string" } } },
+        },
       },
-    },
-  }),
-  requireAuth,
-  async (c) => {
-    const user = c.get("user");
-    const channel = `invalidate-cache:${user.id}`;
+    }),
+    requireAuth,
+    async (c) => {
+      const user = c.get("user");
+      const slug = c.req.param("slug");
+      const channel = `challenge:${user.id}:${slug}`;
 
-    return streamSSE(c, async (stream) => {
-      const subscriber = new Redis(redisConfig);
-      let aborted = false;
+      return streamSSE(c, async (stream) => {
+        const subscriber = new Redis(redisConfig);
+        let aborted = false;
 
-      stream.onAbort(async () => {
-        aborted = true;
-        try {
-          await subscriber.unsubscribe(channel);
-          await subscriber.quit();
-        } catch (err) {
-          c.get("log").error("SSE cleanup error", {
-            channel,
-            error: String(err),
-          });
+        stream.onAbort(async () => {
+          aborted = true;
+          try {
+            await subscriber.unsubscribe(channel);
+            await subscriber.quit();
+          } catch (err) {
+            c.get("log").error("SSE cleanup error", {
+              channel,
+              error: String(err),
+            });
+          }
+        });
+
+        subscriber.on("message", async (_ch: string, message: string) => {
+          try {
+            const parsed = JSON.parse(message) as {
+              event?: string;
+              data?: unknown;
+            };
+            if (parsed.event) {
+              await stream.writeSSE({
+                event: parsed.event,
+                data:
+                  typeof parsed.data === "string"
+                    ? parsed.data
+                    : JSON.stringify(parsed.data),
+              });
+              return;
+            }
+          } catch {
+            // ignore malformed messages
+          }
+        });
+
+        await subscriber.subscribe(channel);
+
+        while (!aborted) {
+          await stream.writeSSE({ data: "", event: "heartbeat" });
+          await stream.sleep(30_000);
         }
       });
+    },
+  )
+  .get(
+    "/invalidate-cache",
+    describeRoute({
+      tags: ["SSE"],
+      summary: "Generic cache-invalidation SSE channel",
+      security: sessionSecurity,
+      responses: {
+        200: {
+          description: "SSE stream",
+          content: { "text/event-stream": { schema: { type: "string" } } },
+        },
+      },
+    }),
+    requireAuth,
+    async (c) => {
+      const user = c.get("user");
+      const channel = `invalidate-cache:${user.id}`;
 
-      subscriber.on("message", async (_ch: string, message: string) => {
-        await stream.writeSSE({
-          data: message,
-          event: "invalidate-cache",
+      return streamSSE(c, async (stream) => {
+        const subscriber = new Redis(redisConfig);
+        let aborted = false;
+
+        stream.onAbort(async () => {
+          aborted = true;
+          try {
+            await subscriber.unsubscribe(channel);
+            await subscriber.quit();
+          } catch (err) {
+            c.get("log").error("SSE cleanup error", {
+              channel,
+              error: String(err),
+            });
+          }
         });
+
+        subscriber.on("message", async (_ch: string, message: string) => {
+          try {
+            const parsed = JSON.parse(message) as {
+              event?: string;
+              data?: unknown;
+            };
+            if (parsed.event) {
+              await stream.writeSSE({
+                event: parsed.event,
+                data:
+                  typeof parsed.data === "string"
+                    ? parsed.data
+                    : JSON.stringify(parsed.data),
+              });
+              return;
+            }
+          } catch {
+            // fall through to legacy path
+          }
+          // Legacy format: publish({ queryKey: [...] }) from xp-award.worker
+          await stream.writeSSE({ data: message, event: "invalidate-cache" });
+        });
+
+        await subscriber.subscribe(channel);
+
+        while (!aborted) {
+          await stream.writeSSE({ data: "", event: "heartbeat" });
+          await stream.sleep(30_000);
+        }
       });
-
-      await subscriber.subscribe(channel);
-
-      while (!aborted) {
-        await stream.writeSSE({ data: "", event: "heartbeat" });
-        await stream.sleep(30_000);
-      }
-    });
-  },
-);
+    },
+  );

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -280,12 +280,16 @@ export const submit = new Hono<AppEnv>().post(
         .where(eq(userXp.userId, userId))
         .limit(1);
       challengeSubmissionQueue
-        .add("challenge-completed", {
-          userId,
-          challengeSlug,
-          difficulty: detail.difficulty,
-          prevTotalXp: xpRow?.totalXp ?? 0,
-        })
+        .add(
+          "challenge-completed",
+          {
+            userId,
+            challengeSlug,
+            difficulty: detail.difficulty,
+            prevTotalXp: xpRow?.totalXp ?? 0,
+          },
+          { jobId: `challenge-completed:${userId}:${challengeSlug}` },
+        )
         .catch((err) => {
           c.get("log").error("challenge-submission job dispatch failed", {
             error: String(err),

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -15,6 +15,7 @@ import { db } from "../db/index";
 import {
   userProgress,
   userSubmission,
+  userXp,
   userXpTransaction,
 } from "../db/schema/index";
 import { trackChallengeSubmitted } from "../lib/analytics-server";
@@ -273,11 +274,17 @@ export const submit = new Hono<AppEnv>().post(
     }
 
     if (!txResult.hasXpAwarded) {
+      const [xpRow] = await db
+        .select({ totalXp: userXp.totalXp })
+        .from(userXp)
+        .where(eq(userXp.userId, userId))
+        .limit(1);
       challengeSubmissionQueue
         .add("challenge-completed", {
           userId,
           challengeSlug,
           difficulty: detail.difficulty,
+          prevTotalXp: xpRow?.totalXp ?? 0,
         })
         .catch((err) => {
           c.get("log").error("challenge-submission job dispatch failed", {

--- a/apps/api/src/services/xp/calculateLevel.ts
+++ b/apps/api/src/services/xp/calculateLevel.ts
@@ -1,34 +1,11 @@
-/**
- * Calculate user's current level/rank based on total XP
- *
- * Determines which rank the user has achieved and their progress to the next rank
- */
-
 import { eq, sql } from "drizzle-orm";
 import { db } from "../../db/index";
 import { userXpTransaction } from "../../db/schema/index";
 import { RANK_THRESHOLDS } from "./constants";
 import type { RankInfo } from "./types";
 
-/**
- * Calculate the current rank for a user based on their total XP
- *
- * @param userId - User ID to calculate rank for
- * @returns RankInfo object with current rank, progress, and next rank threshold
- */
-export async function calculateLevel(userId: string): Promise<RankInfo> {
-  // Get total XP from all transactions
-  const result = await db
-    .select({
-      totalXp: sql<number>`COALESCE(SUM(${userXpTransaction.xpAmount}), 0)`,
-    })
-    .from(userXpTransaction)
-    .where(eq(userXpTransaction.userId, userId));
-
-  const totalXp = result[0]?.totalXp ?? 0;
-
-  // Find the appropriate rank based on total XP
-  // Iterate backwards through thresholds to find the highest qualifying rank
+// Pure in-memory rank computation — no DB access.
+export function getRankFromXp(totalXp: number): RankInfo {
   let currentRankIndex = 0;
   for (let i = RANK_THRESHOLDS.length - 1; i >= 0; i--) {
     if (totalXp >= RANK_THRESHOLDS[i].minXp) {
@@ -40,18 +17,15 @@ export async function calculateLevel(userId: string): Promise<RankInfo> {
   const currentRank = RANK_THRESHOLDS[currentRankIndex];
   const nextRank = RANK_THRESHOLDS[currentRankIndex + 1];
 
-  // Calculate progress to next rank
   let progress: number;
   let nextRankXp: number | null;
 
   if (nextRank) {
-    // Not at max rank - calculate percentage progress
     const xpInCurrentRank = totalXp - currentRank.minXp;
     const xpNeededForNextRank = nextRank.minXp - currentRank.minXp;
     progress = Math.round((xpInCurrentRank / xpNeededForNextRank) * 100);
     nextRankXp = nextRank.minXp;
   } else {
-    // At max rank (Legend)
     progress = 100;
     nextRankXp = null;
   }
@@ -62,4 +36,15 @@ export async function calculateLevel(userId: string): Promise<RankInfo> {
     nextRankXp,
     progress,
   };
+}
+
+export async function calculateLevel(userId: string): Promise<RankInfo> {
+  const result = await db
+    .select({
+      totalXp: sql<number>`COALESCE(SUM(${userXpTransaction.xpAmount}), 0)`,
+    })
+    .from(userXpTransaction)
+    .where(eq(userXpTransaction.userId, userId));
+
+  return getRankFromXp(result[0]?.totalXp ?? 0);
 }

--- a/apps/api/src/services/xp/calculateStreak.ts
+++ b/apps/api/src/services/xp/calculateStreak.ts
@@ -1,21 +1,8 @@
-/**
- * Calculate user's current streak (consecutive days with completions)
- *
- * Uses daily_streak transactions as source of truth
- */
-
-import { and, eq, gte } from "drizzle-orm";
+import { and, eq, gte, isNotNull } from "drizzle-orm";
 import { db } from "../../db/index";
-import { userXpTransaction } from "../../db/schema/index";
+import { userProgress } from "../../db/schema/index";
 import { MAX_STREAK_WINDOW_DAYS } from "./constants";
 
-/**
- * Normalize a date to UTC midnight (start of day in UTC)
- * This ensures consistent date comparison regardless of server timezone
- *
- * @param date - Date to normalize
- * @returns New Date object set to midnight UTC on the same calendar day
- */
 function normalizeToUTCMidnight(date: Date): Date {
   return new Date(
     Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
@@ -23,10 +10,12 @@ function normalizeToUTCMidnight(date: Date): Date {
 }
 
 /**
- * Calculate the current streak for a user
+ * Calculate the current streak for a user (consecutive calendar days with
+ * at least one challenge completion).
  *
- * @param userId - User ID to calculate streak for
- * @returns Number of consecutive days (including today if completed)
+ * Reads userProgress.completedAt — written synchronously by the submit route —
+ * instead of daily_streak XP transactions, which are written asynchronously by
+ * xp-award.worker and may not exist yet when this function is called.
  */
 export async function calculateStreak(userId: string): Promise<number> {
   const today = normalizeToUTCMidnight(new Date());
@@ -34,64 +23,49 @@ export async function calculateStreak(userId: string): Promise<number> {
   const windowStart = new Date(today);
   windowStart.setUTCDate(windowStart.getUTCDate() - MAX_STREAK_WINDOW_DAYS);
 
-  // Get all daily_streak transactions within the window
-  const streakTransactions = await db
-    .select({
-      createdAt: userXpTransaction.createdAt,
-    })
-    .from(userXpTransaction)
+  const completions = await db
+    .select({ completedAt: userProgress.completedAt })
+    .from(userProgress)
     .where(
       and(
-        eq(userXpTransaction.userId, userId),
-        eq(userXpTransaction.action, "daily_streak"),
-        gte(userXpTransaction.createdAt, windowStart),
+        eq(userProgress.userId, userId),
+        eq(userProgress.status, "completed"),
+        isNotNull(userProgress.completedAt),
+        gte(userProgress.completedAt, windowStart),
       ),
-    )
-    .orderBy(userXpTransaction.createdAt);
+    );
 
-  if (streakTransactions.length === 0) {
-    return 0;
-  }
+  if (completions.length === 0) return 0;
 
-  // Get unique days (multiple transactions on same day count as 1)
   const uniqueDays = new Set<string>();
-  for (const transaction of streakTransactions) {
-    const date = normalizeToUTCMidnight(new Date(transaction.createdAt));
-    uniqueDays.add(date.toISOString());
+  for (const { completedAt } of completions) {
+    if (completedAt) {
+      uniqueDays.add(normalizeToUTCMidnight(completedAt).toISOString());
+    }
   }
 
-  // Sort days in descending order (most recent first)
   const sortedDays = Array.from(uniqueDays)
-    .map((dateStr) => new Date(dateStr))
+    .map((d) => new Date(d))
     .sort((a, b) => b.getTime() - a.getTime());
 
-  // Start from most recent day and count backwards
-  let streak = 0;
-  const expectedDate = new Date(today);
-
-  // If last activity was not today or yesterday, streak is broken
   const mostRecentDay = sortedDays[0];
   const daysSinceLastActivity = Math.floor(
     (today.getTime() - mostRecentDay.getTime()) / (1000 * 60 * 60 * 24),
   );
 
-  if (daysSinceLastActivity > 1) {
-    // Streak is broken (more than 1 day gap)
-    return 0;
-  }
+  if (daysSinceLastActivity > 1) return 0;
 
-  // If last activity was yesterday, start from yesterday
+  const expectedDate = new Date(today);
   if (daysSinceLastActivity === 1) {
     expectedDate.setUTCDate(expectedDate.getUTCDate() - 1);
   }
 
-  // Count consecutive days backwards
+  let streak = 0;
   for (const day of sortedDays) {
     if (day.getTime() === expectedDate.getTime()) {
       streak++;
       expectedDate.setUTCDate(expectedDate.getUTCDate() - 1);
     } else {
-      // Gap found, stop counting
       break;
     }
   }

--- a/apps/api/src/services/xp/index.ts
+++ b/apps/api/src/services/xp/index.ts
@@ -9,7 +9,7 @@
  * All functions are tested with comprehensive test coverage
  */
 
-export { calculateLevel } from "./calculateLevel";
+export { calculateLevel, getRankFromXp } from "./calculateLevel";
 // Core functions
 export { calculateStreak } from "./calculateStreak";
 export { calculateXPGain } from "./calculateXPGain";

--- a/apps/api/src/workers/challenge-submission.worker.ts
+++ b/apps/api/src/workers/challenge-submission.worker.ts
@@ -10,7 +10,11 @@ import { all } from "better-all";
 import { Worker } from "bullmq";
 import { and, count, eq, sql } from "drizzle-orm";
 import { db } from "../db/index";
-import { userSubmission, userXpTransaction } from "../db/schema/index";
+import {
+  userProgress,
+  userSubmission,
+  userXpTransaction,
+} from "../db/schema/index";
 import { trackChallengeCompleted } from "../lib/analytics-server";
 import { redis, redisConfig } from "../lib/redis";
 import {
@@ -42,25 +46,41 @@ export function createChallengeSubmissionWorker() {
       const { userId, challengeSlug, difficulty } = job.data;
 
       try {
+        // Idempotency guard: exit early if XP was already awarded for this challenge
+        const [existingTx] = await db
+          .select({ id: userXpTransaction.id })
+          .from(userXpTransaction)
+          .where(
+            and(
+              eq(userXpTransaction.userId, userId),
+              eq(userXpTransaction.challengeSlug, challengeSlug),
+              eq(userXpTransaction.action, "challenge_completed"),
+            ),
+          )
+          .limit(1);
+        if (existingTx) return;
+
         // 1 & 2. Check first challenge + calculate streak in parallel (independent DB queries)
-        const { completedTransactions, currentStreak } = await all({
-          async completedTransactions() {
+        // Uses userProgress (written synchronously by submit route) rather than userXpTransaction
+        // (written asynchronously by xp-award worker) to avoid TOCTOU false positives.
+        const { completedCount, currentStreak } = await all({
+          async completedCount() {
             const [row] = await db
               .select({ count: count() })
-              .from(userXpTransaction)
+              .from(userProgress)
               .where(
                 and(
-                  eq(userXpTransaction.userId, userId),
-                  eq(userXpTransaction.action, "challenge_completed"),
+                  eq(userProgress.userId, userId),
+                  eq(userProgress.status, "completed"),
                 ),
               );
-            return row;
+            return row?.count ?? 0;
           },
           async currentStreak() {
             return calculateStreak(userId);
           },
         });
-        const isFirstChallenge = (completedTransactions?.count ?? 0) === 0;
+        const isFirstChallenge = completedCount === 1;
 
         // 3. Calculate XP amounts
         const xpGain = calculateXPGain({

--- a/apps/api/src/workers/challenge-submission.worker.ts
+++ b/apps/api/src/workers/challenge-submission.worker.ts
@@ -43,7 +43,7 @@ export function createChallengeSubmissionWorker() {
     QUEUE_NAMES.CHALLENGE_SUBMISSION,
     async (job) => {
       const startTime = Date.now();
-      const { userId, challengeSlug, difficulty } = job.data;
+      const { userId, challengeSlug, difficulty, prevTotalXp } = job.data;
 
       try {
         // Idempotency guard: exit early if XP was already awarded for this challenge
@@ -90,16 +90,9 @@ export function createChallengeSubmissionWorker() {
         });
 
         // 4. Gather stats for the celebration SSE event (parallel with analytics)
-        const { prevTotalXp, attemptsCount, commandsCount } = await all({
-          async prevTotalXp() {
-            const [row] = await db
-              .select({
-                total: sql<number>`COALESCE(SUM(${userXpTransaction.xpAmount}), 0)`,
-              })
-              .from(userXpTransaction)
-              .where(eq(userXpTransaction.userId, userId));
-            return row?.total ?? 0;
-          },
+        // prevTotalXp is captured at job-dispatch time (before any XP is awarded),
+        // so it's correct even on retries where XP_AWARD jobs may have already run.
+        const { attemptsCount, commandsCount } = await all({
           async attemptsCount() {
             const [row] = await db
               .select({ count: count() })

--- a/apps/api/src/workers/challenge-submission.worker.ts
+++ b/apps/api/src/workers/challenge-submission.worker.ts
@@ -106,7 +106,7 @@ export function createChallengeSubmissionWorker() {
               );
             return row?.total ?? 0;
           },
-          // Fire-and-forget analytics in parallel
+          // Fire-and-forget — must not propagate errors or the job retries and re-awards XP
           async _analytics() {
             await trackChallengeCompleted(
               userId,
@@ -114,7 +114,7 @@ export function createChallengeSubmissionWorker() {
               difficulty,
               xpGain.total,
               isFirstChallenge,
-            );
+            ).catch(() => {});
           },
         });
 

--- a/apps/api/src/workers/challenge-submission.worker.ts
+++ b/apps/api/src/workers/challenge-submission.worker.ts
@@ -1,3 +1,4 @@
+import type { ChallengeCompletedEventData } from "@kubeasy/api-schemas/sse-events";
 import type { XpAwardPayload } from "@kubeasy/jobs";
 import {
   type ChallengeSubmissionPayload,
@@ -7,12 +8,16 @@ import {
 import { metrics } from "@opentelemetry/api";
 import { all } from "better-all";
 import { Worker } from "bullmq";
-import { and, count, eq } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import { db } from "../db/index";
-import { userXpTransaction } from "../db/schema/index";
+import { userSubmission, userXpTransaction } from "../db/schema/index";
 import { trackChallengeCompleted } from "../lib/analytics-server";
-import { redisConfig } from "../lib/redis";
-import { calculateStreak, calculateXPGain } from "../services/xp/index";
+import { redis, redisConfig } from "../lib/redis";
+import {
+  calculateStreak,
+  calculateXPGain,
+  getRankFromXp,
+} from "../services/xp/index";
 import type { ChallengeDifficulty } from "../services/xp/types";
 
 const meter = metrics.getMeter("kubeasy-api-workers");
@@ -64,14 +69,57 @@ export function createChallengeSubmissionWorker() {
           currentStreak,
         });
 
-        // 4. Fire analytics (fire-and-forget style, errors logged internally)
-        await trackChallengeCompleted(
-          userId,
-          challengeSlug,
-          difficulty,
-          xpGain.total,
-          isFirstChallenge,
-        );
+        // 4. Gather stats for the celebration SSE event (parallel with analytics)
+        const { prevTotalXp, attemptsCount, commandsCount } = await all({
+          async prevTotalXp() {
+            const [row] = await db
+              .select({
+                total: sql<number>`COALESCE(SUM(${userXpTransaction.xpAmount}), 0)`,
+              })
+              .from(userXpTransaction)
+              .where(eq(userXpTransaction.userId, userId));
+            return row?.total ?? 0;
+          },
+          async attemptsCount() {
+            const [row] = await db
+              .select({ count: count() })
+              .from(userSubmission)
+              .where(
+                and(
+                  eq(userSubmission.userId, userId),
+                  eq(userSubmission.challengeSlug, challengeSlug),
+                ),
+              );
+            return row?.count ?? 0;
+          },
+          async commandsCount() {
+            const [row] = await db
+              .select({
+                total: sql<number>`COALESCE(SUM(jsonb_array_length(COALESCE(${userSubmission.auditEvents}, '[]'::jsonb))), 0)`,
+              })
+              .from(userSubmission)
+              .where(
+                and(
+                  eq(userSubmission.userId, userId),
+                  eq(userSubmission.challengeSlug, challengeSlug),
+                ),
+              );
+            return row?.total ?? 0;
+          },
+          // Fire-and-forget analytics in parallel
+          async _analytics() {
+            await trackChallengeCompleted(
+              userId,
+              challengeSlug,
+              difficulty,
+              xpGain.total,
+              isFirstChallenge,
+            );
+          },
+        });
+
+        const prevRank = getRankFromXp(prevTotalXp);
+        const newRank = getRankFromXp(prevTotalXp + xpGain.total);
 
         // 5. Dispatch XP_AWARD jobs in parallel
         await all({
@@ -110,6 +158,33 @@ export function createChallengeSubmissionWorker() {
             }
           },
         });
+
+        // 6. Emit celebration SSE event
+        const eventData: ChallengeCompletedEventData = {
+          challengeSlug,
+          difficulty: difficulty as ChallengeDifficulty,
+          xpGain: {
+            base: xpGain.baseXP,
+            firstChallenge: xpGain.firstChallengeBonus,
+            streak: xpGain.streakBonus,
+            total: xpGain.total,
+          },
+          isFirstChallenge,
+          currentStreak,
+          attemptsCount,
+          commandsCount,
+          leveledUp: prevRank.name !== newRank.name,
+          prevRank,
+          newRank,
+        };
+        await redis
+          .publish(
+            `challenge:${userId}:${challengeSlug}`,
+            JSON.stringify({ event: "challenge-completed", data: eventData }),
+          )
+          .catch(() => {
+            // Non-critical — don't fail the job if SSE publish fails
+          });
 
         jobCounter.add(1, {
           queue: QUEUE_NAMES.CHALLENGE_SUBMISSION,

--- a/apps/api/src/workers/challenge-submission.worker.ts
+++ b/apps/api/src/workers/challenge-submission.worker.ts
@@ -5,7 +5,7 @@ import {
   createQueue,
   QUEUE_NAMES,
 } from "@kubeasy/jobs";
-import { metrics } from "@opentelemetry/api";
+import { metrics, SpanStatusCode, trace } from "@opentelemetry/api";
 import { all } from "better-all";
 import { Worker } from "bullmq";
 import { and, count, eq, sql } from "drizzle-orm";
@@ -134,40 +134,50 @@ export function createChallengeSubmissionWorker() {
         const prevRank = getRankFromXp(prevTotalXp);
         const newRank = getRankFromXp(prevTotalXp + xpGain.total);
 
-        // 5. Dispatch XP_AWARD jobs in parallel
+        // 5. Dispatch XP_AWARD jobs in parallel with deterministic jobIds so
+        //    re-enqueues on retry are deduplicated at the BullMQ level.
         await all({
-          // Base XP always awarded
           async base() {
-            return xpAwardQueue.add("xp-base", {
-              userId,
-              challengeSlug,
-              xpAmount: xpGain.baseXP,
-              action: "challenge_completed",
-              description: `Completed ${difficulty} challenge`,
-            } satisfies XpAwardPayload);
+            return xpAwardQueue.add(
+              "xp-base",
+              {
+                userId,
+                challengeSlug,
+                xpAmount: xpGain.baseXP,
+                action: "challenge_completed",
+                description: `Completed ${difficulty} challenge`,
+              } satisfies XpAwardPayload,
+              { jobId: `xp-base:${userId}:${challengeSlug}` },
+            );
           },
-          // First challenge bonus
           async firstChallenge() {
             if (isFirstChallenge && xpGain.firstChallengeBonus > 0) {
-              return xpAwardQueue.add("xp-first-challenge", {
-                userId,
-                challengeSlug,
-                xpAmount: xpGain.firstChallengeBonus,
-                action: "first_challenge",
-                description: "First challenge bonus",
-              } satisfies XpAwardPayload);
+              return xpAwardQueue.add(
+                "xp-first-challenge",
+                {
+                  userId,
+                  challengeSlug,
+                  xpAmount: xpGain.firstChallengeBonus,
+                  action: "first_challenge",
+                  description: "First challenge bonus",
+                } satisfies XpAwardPayload,
+                { jobId: `xp-first-challenge:${userId}:${challengeSlug}` },
+              );
             }
           },
-          // Streak bonus
           async streak() {
             if (xpGain.streakBonus > 0) {
-              return xpAwardQueue.add("xp-streak", {
-                userId,
-                challengeSlug,
-                xpAmount: xpGain.streakBonus,
-                action: "daily_streak",
-                description: `${currentStreak} day streak bonus`,
-              } satisfies XpAwardPayload);
+              return xpAwardQueue.add(
+                "xp-streak",
+                {
+                  userId,
+                  challengeSlug,
+                  xpAmount: xpGain.streakBonus,
+                  action: "daily_streak",
+                  description: `${currentStreak} day streak bonus`,
+                } satisfies XpAwardPayload,
+                { jobId: `xp-streak:${userId}:${challengeSlug}` },
+              );
             }
           },
         });
@@ -204,6 +214,9 @@ export function createChallengeSubmissionWorker() {
           status: "success",
         });
       } catch (error) {
+        const span = trace.getActiveSpan();
+        span?.recordException(error as Error);
+        span?.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
         jobCounter.add(1, {
           queue: QUEUE_NAMES.CHALLENGE_SUBMISSION,
           status: "error",

--- a/apps/api/src/workers/xp-award.worker.ts
+++ b/apps/api/src/workers/xp-award.worker.ts
@@ -18,25 +18,28 @@ export function createXpAwardWorker() {
       log.set({ jobId: job.id, worker: "xp-award" });
       const { userId, challengeSlug, xpAmount, action, description } = job.data;
 
-      // 1. Atomic userXp UPSERT (add xpAmount to totalXp)
-      await db
-        .insert(userXp)
-        .values({ userId, totalXp: xpAmount })
-        .onConflictDoUpdate({
-          target: userXp.userId,
-          set: {
-            totalXp: sql`${userXp.totalXp} + ${xpAmount}`,
-            updatedAt: new Date(),
-          },
-        });
+      // 1. Write the XP transaction record first — acts as the idempotency key.
+      //    ON CONFLICT DO NOTHING means retried jobs skip the XP update safely.
+      // 2. Atomically increment userXp total, but only if the transaction was new.
+      await db.transaction(async (tx) => {
+        const [inserted] = await tx
+          .insert(userXpTransaction)
+          .values({ userId, action, xpAmount, challengeSlug, description })
+          .onConflictDoNothing()
+          .returning({ id: userXpTransaction.id });
 
-      // 2. Insert userXpTransaction record
-      await db.insert(userXpTransaction).values({
-        userId,
-        action,
-        xpAmount,
-        challengeSlug,
-        description,
+        if (!inserted) return;
+
+        await tx
+          .insert(userXp)
+          .values({ userId, totalXp: xpAmount })
+          .onConflictDoUpdate({
+            target: userXp.userId,
+            set: {
+              totalXp: sql`${userXp.totalXp} + ${xpAmount}`,
+              updatedAt: new Date(),
+            },
+          });
       });
 
       // 3. Publish SSE cache-invalidation event for user's XP query

--- a/apps/web/src/components/challenge-completion-modal.tsx
+++ b/apps/web/src/components/challenge-completion-modal.tsx
@@ -1,0 +1,305 @@
+import type { ChallengeCompletedEventData } from "@kubeasy/api-schemas/sse-events";
+import { Button } from "@kubeasy/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@kubeasy/ui/dialog";
+import { CheckCircle2, Link, Trophy, Zap } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+interface ChallengeCompletionModalProps {
+  payload: ChallengeCompletedEventData | null;
+  onClose: () => void;
+}
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.912-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+function BlueSkyIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 360 320"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M180 141.964C163.699 110.262 119.308 51.1 78.476 26.703 39.717 3.23 16.451 0 5.065 0c-11.34 0-5.072 19.52-.699 27.418 5.383 9.697 24.046 40.816 35.376 57.254C51.204 101.153 68.54 114.5 81.059 119.5c-12.519-5-48.098-35.47-64.815-43.497-6.77-3.364-17.218-9.73-19.4-3.764-4.062 11.15 4.014 17.427 13.046 25.085 22.83 19.406 65.543 57.614 71.77 62.526-6.228-4.912-62.02-28.4-80.58-35.44-8.524-3.265-19.79-6.64-16.07 7.247 4.003 14.764 52.887 49.79 83.76 65.463-32.68-4.914-60.16-1.52-61.45 11.217-1.176 11.598 37.584 27.55 63.614 27.55H180" />
+      <path d="M180 141.964C196.301 110.262 240.692 51.1 281.524 26.703 320.283 3.23 343.549 0 354.935 0c11.34 0 5.072 19.52.699 27.418-5.383 9.697-24.046 40.816-35.376 57.254-11.463 17.43-28.8 30.778-41.318 35.778 12.519-5 48.098-35.47 64.815-43.497 6.77-3.364 17.218-9.73 19.4-3.764 4.062 11.15-4.014 17.427-13.046 25.085-22.83 19.406-65.543 57.614-71.77 62.526 6.228-4.912 62.02-28.4 80.58-35.44 8.524-3.265 19.79-6.64 16.07 7.247-4.003 14.764-52.887 49.79-83.76 65.463 32.68-4.914 60.16-1.52 61.45 11.217 1.176 11.598-37.584 27.55-63.614 27.55H180" />
+    </svg>
+  );
+}
+
+function LinkedInIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+const CONFETTI_COLORS = [
+  "bg-yellow-400",
+  "bg-pink-400",
+  "bg-blue-400",
+  "bg-green-400",
+  "bg-purple-400",
+  "bg-orange-400",
+];
+
+const CONFETTI_PIECES = Array.from({ length: 24 }, (_, i) => ({
+  id: `confetti-${i}`,
+  color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+  left: `${(i * 37 + 5) % 95}%`,
+  delay: `${(i * 0.13) % 2}s`,
+  width: i % 3 === 0 ? "w-2" : "w-3",
+  height: i % 3 === 0 ? "h-3" : "h-2",
+}));
+
+function ConfettiPiece({
+  color,
+  left,
+  delay,
+  width,
+  height,
+}: {
+  color: string;
+  left: string;
+  delay: string;
+  width: string;
+  height: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "absolute animate-confetti rounded-sm",
+        color,
+        width,
+        height,
+      )}
+      style={{ left, animationDelay: delay }}
+    />
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex flex-col items-center gap-1 p-3 bg-white neo-border rounded-lg flex-1">
+      <span className="text-2xl font-black">{value}</span>
+      <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export function ChallengeCompletionModal({
+  payload,
+  onClose,
+}: ChallengeCompletionModalProps) {
+  const challengeUrl = payload
+    ? `${window.location.origin}/challenges/${payload.challengeSlug}`
+    : "";
+
+  const shareText = payload
+    ? encodeURIComponent(
+        `Just completed the "${payload.challengeSlug}" Kubernetes challenge on @kubeasy_dev! 🚀 (+${payload.xpGain.total} XP)`,
+      )
+    : "";
+  const shareUrl = encodeURIComponent(challengeUrl);
+
+  const shareLinks = {
+    twitter: `https://twitter.com/intent/tweet?text=${shareText}&url=${shareUrl}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${shareUrl}`,
+    bluesky: `https://bsky.app/intent/compose?text=${shareText}%20${shareUrl}`,
+  };
+
+  function copyLink() {
+    navigator.clipboard.writeText(challengeUrl).then(() => {
+      toast.success("Link copied!");
+    });
+  }
+
+  return (
+    <Dialog
+      open={payload !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      {payload && (
+        <DialogContent className="max-w-lg neo-border-thick neo-shadow-xl overflow-hidden">
+          {/* Confetti */}
+          <div
+            className="absolute inset-0 pointer-events-none overflow-hidden"
+            aria-hidden="true"
+          >
+            {CONFETTI_PIECES.map((p) => (
+              <ConfettiPiece key={p.id} {...p} />
+            ))}
+          </div>
+
+          <DialogHeader className="relative z-10">
+            <DialogTitle className="text-2xl font-black flex items-center gap-3">
+              <Trophy className="h-7 w-7 text-yellow-500" />
+              Challenge Completed!
+            </DialogTitle>
+            <DialogDescription className="font-semibold">
+              <span className="capitalize">
+                {payload.challengeSlug.replace(/-/g, " ")}
+              </span>
+              {" · "}
+              <span className="capitalize">
+                {
+                  { easy: "Easy", medium: "Medium", hard: "Hard" }[
+                    payload.difficulty
+                  ]
+                }
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="relative z-10 space-y-4 mt-2">
+            {/* Stats row */}
+            <div className="flex gap-2">
+              <StatCard label="Attempts" value={payload.attemptsCount} />
+              <StatCard label="K8s Calls" value={payload.commandsCount} />
+            </div>
+
+            {/* XP card */}
+            <div className="bg-primary text-primary-foreground neo-border-thick rounded-lg p-4 space-y-2">
+              <div className="flex items-center gap-2">
+                <Zap className="h-5 w-5" />
+                <span className="font-black text-lg">XP Earned</span>
+                <span className="ml-auto text-3xl font-black">
+                  +{payload.xpGain.total}
+                </span>
+              </div>
+              <div className="space-y-1 text-sm font-medium opacity-90">
+                <div className="flex justify-between">
+                  <span>Base XP</span>
+                  <span>+{payload.xpGain.base}</span>
+                </div>
+                {payload.xpGain.firstChallenge > 0 && (
+                  <div className="flex justify-between">
+                    <span>First challenge bonus</span>
+                    <span>+{payload.xpGain.firstChallenge}</span>
+                  </div>
+                )}
+                {payload.xpGain.streak > 0 && (
+                  <div className="flex justify-between">
+                    <span>Streak bonus ({payload.currentStreak} days)</span>
+                    <span>+{payload.xpGain.streak}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Level-up banner */}
+            {payload.leveledUp && (
+              <div className="bg-yellow-50 neo-border-thick neo-border-amber rounded-lg p-3 flex items-center gap-3">
+                <CheckCircle2 className="h-5 w-5 text-yellow-600 flex-shrink-0" />
+                <p className="font-black text-yellow-900">
+                  You ranked up to{" "}
+                  <span className="text-yellow-700">
+                    {payload.newRank.name}
+                  </span>
+                  !
+                </p>
+              </div>
+            )}
+
+            {/* First challenge banner */}
+            {payload.isFirstChallenge && !payload.leveledUp && (
+              <div className="bg-blue-50 neo-border-thick rounded-lg p-3 flex items-center gap-3">
+                <CheckCircle2 className="h-5 w-5 text-blue-600 flex-shrink-0" />
+                <p className="font-bold text-blue-900">
+                  First challenge completed!
+                </p>
+              </div>
+            )}
+
+            {/* Share buttons */}
+            <div className="space-y-2">
+              <p className="text-sm font-bold">Share your achievement:</p>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="neo-border font-bold gap-2"
+                  asChild
+                >
+                  <a
+                    href={shareLinks.twitter}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <XIcon className="h-4 w-4" />
+                    Post
+                  </a>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="neo-border font-bold gap-2"
+                  asChild
+                >
+                  <a
+                    href={shareLinks.linkedin}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <LinkedInIcon className="h-4 w-4" />
+                    Share
+                  </a>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="neo-border font-bold gap-2"
+                  asChild
+                >
+                  <a
+                    href={shareLinks.bluesky}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <BlueSkyIcon className="h-4 w-4" />
+                    Post
+                  </a>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="neo-border font-bold gap-2"
+                  onClick={copyLink}
+                >
+                  <Link className="h-4 w-4" />
+                  Copy link
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/challenge-completion-modal.tsx
+++ b/apps/web/src/components/challenge-completion-modal.tsx
@@ -115,13 +115,14 @@ export function ChallengeCompletionModal({
   payload,
   onClose,
 }: ChallengeCompletionModalProps) {
-  const challengeUrl = payload
-    ? `${window.location.origin}/challenges/${payload.challengeSlug}`
-    : "";
+  const challengeUrl =
+    typeof window !== "undefined" && payload
+      ? `${window.location.origin}/challenges/${payload.challengeSlug}`
+      : "";
 
   const shareText = payload
     ? encodeURIComponent(
-        `Just completed the "${payload.challengeSlug}" Kubernetes challenge on @kubeasy_dev! 🚀 (+${payload.xpGain.total} XP)`,
+        `Just completed the "${payload.challengeSlug.replace(/-/g, " ")}" Kubernetes challenge on @kubeasy_dev! 🚀 (+${payload.xpGain.total} XP)`,
       )
     : "";
   const shareUrl = encodeURIComponent(challengeUrl);
@@ -133,9 +134,14 @@ export function ChallengeCompletionModal({
   };
 
   function copyLink() {
-    navigator.clipboard.writeText(challengeUrl).then(() => {
-      toast.success("Link copied!");
-    });
+    navigator.clipboard.writeText(challengeUrl).then(
+      () => {
+        toast.success("Link copied!");
+      },
+      () => {
+        toast.error("Failed to copy link");
+      },
+    );
   }
 
   return (

--- a/apps/web/src/components/challenge-completion-modal.tsx
+++ b/apps/web/src/components/challenge-completion-modal.tsx
@@ -111,6 +111,179 @@ function StatCard({ label, value }: { label: string; value: string | number }) {
   );
 }
 
+function CompletionModalContent({
+  payload,
+  challengeUrl,
+  onCopyLink,
+}: {
+  payload: ChallengeCompletedEventData;
+  challengeUrl: string;
+  onCopyLink: () => void;
+}) {
+  const shareText = encodeURIComponent(
+    `Just completed the "${payload.challengeSlug.replace(/-/g, " ")}" Kubernetes challenge on @kubeasy_dev! 🚀 (+${payload.xpGain.total} XP)`,
+  );
+  const shareUrl = encodeURIComponent(challengeUrl);
+  const shareLinks = {
+    twitter: `https://twitter.com/intent/tweet?text=${shareText}&url=${shareUrl}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${shareUrl}`,
+    bluesky: `https://bsky.app/intent/compose?text=${shareText}%20${shareUrl}`,
+  };
+
+  return (
+    <DialogContent className="max-w-lg neo-border-thick neo-shadow-xl overflow-hidden">
+      {/* Confetti */}
+      <div
+        className="absolute inset-0 pointer-events-none overflow-hidden"
+        aria-hidden="true"
+      >
+        {CONFETTI_PIECES.map((p) => (
+          <ConfettiPiece key={p.id} {...p} />
+        ))}
+      </div>
+
+      <DialogHeader className="relative z-10">
+        <DialogTitle className="text-2xl font-black flex items-center gap-3">
+          <Trophy className="h-7 w-7 text-yellow-500" />
+          Challenge Completed!
+        </DialogTitle>
+        <DialogDescription className="font-semibold">
+          <span className="capitalize">
+            {payload.challengeSlug.replace(/-/g, " ")}
+          </span>
+          {" · "}
+          <span className="capitalize">
+            {
+              { easy: "Easy", medium: "Medium", hard: "Hard" }[
+                payload.difficulty
+              ]
+            }
+          </span>
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="relative z-10 space-y-4 mt-2">
+        {/* Stats row */}
+        <div className="flex gap-2">
+          <StatCard label="Attempts" value={payload.attemptsCount} />
+          <StatCard label="K8s Calls" value={payload.commandsCount} />
+        </div>
+
+        {/* XP card */}
+        <div className="bg-primary text-primary-foreground neo-border-thick rounded-lg p-4 space-y-2">
+          <div className="flex items-center gap-2">
+            <Zap className="h-5 w-5" />
+            <span className="font-black text-lg">XP Earned</span>
+            <span className="ml-auto text-3xl font-black">
+              +{payload.xpGain.total}
+            </span>
+          </div>
+          <div className="space-y-1 text-sm font-medium opacity-90">
+            <div className="flex justify-between">
+              <span>Base XP</span>
+              <span>+{payload.xpGain.base}</span>
+            </div>
+            {payload.xpGain.firstChallenge > 0 && (
+              <div className="flex justify-between">
+                <span>First challenge bonus</span>
+                <span>+{payload.xpGain.firstChallenge}</span>
+              </div>
+            )}
+            {payload.xpGain.streak > 0 && (
+              <div className="flex justify-between">
+                <span>Streak bonus ({payload.currentStreak} days)</span>
+                <span>+{payload.xpGain.streak}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Level-up banner */}
+        {payload.leveledUp && (
+          <div className="bg-yellow-50 neo-border-thick neo-border-amber rounded-lg p-3 flex items-center gap-3">
+            <CheckCircle2 className="h-5 w-5 text-yellow-600 flex-shrink-0" />
+            <p className="font-black text-yellow-900">
+              You ranked up to{" "}
+              <span className="text-yellow-700">{payload.newRank.name}</span>!
+            </p>
+          </div>
+        )}
+
+        {/* First challenge banner */}
+        {payload.isFirstChallenge && !payload.leveledUp && (
+          <div className="bg-blue-50 neo-border-thick rounded-lg p-3 flex items-center gap-3">
+            <CheckCircle2 className="h-5 w-5 text-blue-600 flex-shrink-0" />
+            <p className="font-bold text-blue-900">
+              First challenge completed!
+            </p>
+          </div>
+        )}
+
+        {/* Share buttons */}
+        <div className="space-y-2">
+          <p className="text-sm font-bold">Share your achievement:</p>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="neo-border font-bold gap-2"
+              asChild
+            >
+              <a
+                href={shareLinks.twitter}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <XIcon className="h-4 w-4" />
+                Post
+              </a>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="neo-border font-bold gap-2"
+              asChild
+            >
+              <a
+                href={shareLinks.linkedin}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <LinkedInIcon className="h-4 w-4" />
+                Share
+              </a>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="neo-border font-bold gap-2"
+              asChild
+            >
+              <a
+                href={shareLinks.bluesky}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <BlueSkyIcon className="h-4 w-4" />
+                Post
+              </a>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="neo-border font-bold gap-2"
+              onClick={onCopyLink}
+            >
+              <Link className="h-4 w-4" />
+              Copy link
+            </Button>
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  );
+}
+
 export function ChallengeCompletionModal({
   payload,
   onClose,
@@ -119,19 +292,6 @@ export function ChallengeCompletionModal({
     typeof window !== "undefined" && payload
       ? `${window.location.origin}/challenges/${payload.challengeSlug}`
       : "";
-
-  const shareText = payload
-    ? encodeURIComponent(
-        `Just completed the "${payload.challengeSlug.replace(/-/g, " ")}" Kubernetes challenge on @kubeasy_dev! 🚀 (+${payload.xpGain.total} XP)`,
-      )
-    : "";
-  const shareUrl = encodeURIComponent(challengeUrl);
-
-  const shareLinks = {
-    twitter: `https://twitter.com/intent/tweet?text=${shareText}&url=${shareUrl}`,
-    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${shareUrl}`,
-    bluesky: `https://bsky.app/intent/compose?text=${shareText}%20${shareUrl}`,
-  };
 
   function copyLink() {
     navigator.clipboard.writeText(challengeUrl).then(
@@ -152,159 +312,11 @@ export function ChallengeCompletionModal({
       }}
     >
       {payload && (
-        <DialogContent className="max-w-lg neo-border-thick neo-shadow-xl overflow-hidden">
-          {/* Confetti */}
-          <div
-            className="absolute inset-0 pointer-events-none overflow-hidden"
-            aria-hidden="true"
-          >
-            {CONFETTI_PIECES.map((p) => (
-              <ConfettiPiece key={p.id} {...p} />
-            ))}
-          </div>
-
-          <DialogHeader className="relative z-10">
-            <DialogTitle className="text-2xl font-black flex items-center gap-3">
-              <Trophy className="h-7 w-7 text-yellow-500" />
-              Challenge Completed!
-            </DialogTitle>
-            <DialogDescription className="font-semibold">
-              <span className="capitalize">
-                {payload.challengeSlug.replace(/-/g, " ")}
-              </span>
-              {" · "}
-              <span className="capitalize">
-                {
-                  { easy: "Easy", medium: "Medium", hard: "Hard" }[
-                    payload.difficulty
-                  ]
-                }
-              </span>
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="relative z-10 space-y-4 mt-2">
-            {/* Stats row */}
-            <div className="flex gap-2">
-              <StatCard label="Attempts" value={payload.attemptsCount} />
-              <StatCard label="K8s Calls" value={payload.commandsCount} />
-            </div>
-
-            {/* XP card */}
-            <div className="bg-primary text-primary-foreground neo-border-thick rounded-lg p-4 space-y-2">
-              <div className="flex items-center gap-2">
-                <Zap className="h-5 w-5" />
-                <span className="font-black text-lg">XP Earned</span>
-                <span className="ml-auto text-3xl font-black">
-                  +{payload.xpGain.total}
-                </span>
-              </div>
-              <div className="space-y-1 text-sm font-medium opacity-90">
-                <div className="flex justify-between">
-                  <span>Base XP</span>
-                  <span>+{payload.xpGain.base}</span>
-                </div>
-                {payload.xpGain.firstChallenge > 0 && (
-                  <div className="flex justify-between">
-                    <span>First challenge bonus</span>
-                    <span>+{payload.xpGain.firstChallenge}</span>
-                  </div>
-                )}
-                {payload.xpGain.streak > 0 && (
-                  <div className="flex justify-between">
-                    <span>Streak bonus ({payload.currentStreak} days)</span>
-                    <span>+{payload.xpGain.streak}</span>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Level-up banner */}
-            {payload.leveledUp && (
-              <div className="bg-yellow-50 neo-border-thick neo-border-amber rounded-lg p-3 flex items-center gap-3">
-                <CheckCircle2 className="h-5 w-5 text-yellow-600 flex-shrink-0" />
-                <p className="font-black text-yellow-900">
-                  You ranked up to{" "}
-                  <span className="text-yellow-700">
-                    {payload.newRank.name}
-                  </span>
-                  !
-                </p>
-              </div>
-            )}
-
-            {/* First challenge banner */}
-            {payload.isFirstChallenge && !payload.leveledUp && (
-              <div className="bg-blue-50 neo-border-thick rounded-lg p-3 flex items-center gap-3">
-                <CheckCircle2 className="h-5 w-5 text-blue-600 flex-shrink-0" />
-                <p className="font-bold text-blue-900">
-                  First challenge completed!
-                </p>
-              </div>
-            )}
-
-            {/* Share buttons */}
-            <div className="space-y-2">
-              <p className="text-sm font-bold">Share your achievement:</p>
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="neo-border font-bold gap-2"
-                  asChild
-                >
-                  <a
-                    href={shareLinks.twitter}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <XIcon className="h-4 w-4" />
-                    Post
-                  </a>
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="neo-border font-bold gap-2"
-                  asChild
-                >
-                  <a
-                    href={shareLinks.linkedin}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <LinkedInIcon className="h-4 w-4" />
-                    Share
-                  </a>
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="neo-border font-bold gap-2"
-                  asChild
-                >
-                  <a
-                    href={shareLinks.bluesky}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <BlueSkyIcon className="h-4 w-4" />
-                    Post
-                  </a>
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="neo-border font-bold gap-2"
-                  onClick={copyLink}
-                >
-                  <Link className="h-4 w-4" />
-                  Copy link
-                </Button>
-              </div>
-            </div>
-          </div>
-        </DialogContent>
+        <CompletionModalContent
+          payload={payload}
+          challengeUrl={challengeUrl}
+          onCopyLink={copyLink}
+        />
       )}
     </Dialog>
   );

--- a/apps/web/src/components/challenge-mission.tsx
+++ b/apps/web/src/components/challenge-mission.tsx
@@ -109,7 +109,11 @@ export function ChallengeMission({ slug }: ChallengeMissionProps) {
   });
 
   const status = statusData?.status ?? "not_started";
-  useChallengeCelebrationSSE(slug, isAuthenticated, handleChallengeCompleted);
+  useChallengeCelebrationSSE(
+    slug,
+    isAuthenticated && status !== "completed",
+    handleChallengeCompleted,
+  );
   const isLoading =
     isLoadingObjectives ||
     isSessionLoading ||

--- a/apps/web/src/components/challenge-mission.tsx
+++ b/apps/web/src/components/challenge-mission.tsx
@@ -1,3 +1,4 @@
+import type { ChallengeCompletedEventData } from "@kubeasy/api-schemas/sse-events";
 import { Button } from "@kubeasy/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@kubeasy/ui/card";
 import {
@@ -18,8 +19,9 @@ import {
   Target,
   XCircle,
 } from "lucide-react";
-import { useMemo, useState } from "react";
-import { useInvalidateCacheSSE } from "@/hooks/use-invalidate-cache-sse";
+import { useCallback, useMemo, useState } from "react";
+import { ChallengeCompletionModal } from "@/components/challenge-completion-modal";
+import { useChallengeCelebrationSSE } from "@/hooks/use-challenge-celebration-sse";
 import { authClient } from "@/lib/auth-client";
 import {
   challengeObjectivesOptions,
@@ -73,6 +75,15 @@ interface DisplayObjective {
 
 export function ChallengeMission({ slug }: ChallengeMissionProps) {
   const [showHistory, setShowHistory] = useState(false);
+  const [celebrationPayload, setCelebrationPayload] =
+    useState<ChallengeCompletedEventData | null>(null);
+
+  const handleChallengeCompleted = useCallback(
+    (data: ChallengeCompletedEventData) => {
+      setCelebrationPayload(data);
+    },
+    [],
+  );
 
   const { data: session, isPending: isSessionLoading } =
     authClient.useSession();
@@ -98,7 +109,7 @@ export function ChallengeMission({ slug }: ChallengeMissionProps) {
   });
 
   const status = statusData?.status ?? "not_started";
-  useInvalidateCacheSSE(status === "in_progress");
+  useChallengeCelebrationSSE(slug, isAuthenticated, handleChallengeCompleted);
   const isLoading =
     isLoadingObjectives ||
     isSessionLoading ||
@@ -171,203 +182,213 @@ export function ChallengeMission({ slug }: ChallengeMissionProps) {
     (submissionsData as SubmissionsOutput | undefined)?.submissions ?? [];
 
   return (
-    <Card className="neo-border-thick neo-shadow-xl bg-secondary">
-      <CardHeader>
-        <CardTitle className="text-2xl font-black flex items-center gap-3">
-          <Target className="h-6 w-6" />
-          Your Mission
-          {totalObjectives > 0 && (
-            <span className="ml-auto text-base font-bold">
-              {passedObjectives}/{totalObjectives}
-            </span>
+    <>
+      <ChallengeCompletionModal
+        payload={celebrationPayload}
+        onClose={() => setCelebrationPayload(null)}
+      />
+      <Card className="neo-border-thick neo-shadow-xl bg-secondary">
+        <CardHeader>
+          <CardTitle className="text-2xl font-black flex items-center gap-3">
+            <Target className="h-6 w-6" />
+            Your Mission
+            {totalObjectives > 0 && (
+              <span className="ml-auto text-base font-bold">
+                {passedObjectives}/{totalObjectives}
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Loading state */}
+          {isLoading && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm font-medium">
+                Loading validation status...
+              </span>
+            </div>
           )}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Loading state */}
-        {isLoading && (
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            <span className="text-sm font-medium">
-              Loading validation status...
-            </span>
-          </div>
-        )}
 
-        {/* Success Message - only when completed */}
-        {isCompleted && (
-          <div className="bg-green-50 neo-border-thick rounded-lg p-4">
-            <div className="flex items-center gap-3">
-              <CheckCircle2 className="h-6 w-6 text-green-600 flex-shrink-0" />
-              <p className="font-bold text-green-900">
-                Congratulations! You&apos;ve successfully completed this
-                challenge.
-              </p>
-            </div>
-          </div>
-        )}
-
-        {/* Objectives Checklist */}
-        {!isLoading && displayObjectives.length > 0 && (
-          <div className="space-y-3">
-            <p className="text-sm font-bold">
-              Complete the objectives below and submit your solution:
-            </p>
-
-            <div className="space-y-2">
-              {displayObjectives.map((obj) => (
-                <div
-                  key={obj.id}
-                  className={cn(
-                    "flex items-start gap-3 p-3 rounded-lg neo-border",
-                    obj.status === true
-                      ? "bg-green-50"
-                      : obj.status === false
-                        ? "bg-red-50"
-                        : "bg-white",
-                  )}
-                >
-                  <StatusIcon objStatus={obj.status} />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <p className="font-bold">{obj.title}</p>
-                      <span
-                        className={cn(
-                          "text-xs font-semibold px-2 py-0.5 rounded-full",
-                          CATEGORY_COLORS[obj.category] ||
-                            "bg-gray-100 text-gray-700",
-                        )}
-                      >
-                        {CATEGORY_LABELS[obj.category] || obj.category}
-                      </span>
-                    </div>
-                    {obj.description && (
-                      <p className="text-sm text-foreground/70 mt-1">
-                        {obj.description}
-                      </p>
-                    )}
-                    {obj.message && (
-                      <p
-                        className={cn(
-                          "text-sm mt-2 font-medium",
-                          obj.status === true
-                            ? "text-green-700"
-                            : "text-red-600",
-                        )}
-                      >
-                        {obj.message}
-                      </p>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Last Updated */}
-            {hasAnySubmission &&
-              (validationStatus as LatestValidationStatusOutput | undefined)
-                ?.timestamp && (
-                <p className="text-xs text-muted-foreground text-right font-medium">
-                  Last updated:{" "}
-                  {new Date(
-                    String(
-                      (validationStatus as LatestValidationStatusOutput)
-                        .timestamp,
-                    ),
-                  ).toLocaleString()}
+          {/* Success Message - only when completed */}
+          {isCompleted && (
+            <div className="bg-green-50 neo-border-thick rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <CheckCircle2 className="h-6 w-6 text-green-600 flex-shrink-0" />
+                <p className="font-bold text-green-900">
+                  Congratulations! You&apos;ve successfully completed this
+                  challenge.
                 </p>
-              )}
-          </div>
-        )}
-
-        {/* CLI Commands */}
-        <div className="space-y-3">
-          {isCompleted ? (
-            <>
-              <p className="text-sm font-bold">Clean up the resources with:</p>
-              <div className="bg-black text-green-400 p-3 rounded-lg neo-border-thick font-mono text-sm">
-                <span className="text-gray-500">$</span> kubeasy challenge clean{" "}
-                {slug}
               </div>
-            </>
-          ) : status === "not_started" ? (
-            <>
+            </div>
+          )}
+
+          {/* Objectives Checklist */}
+          {!isLoading && displayObjectives.length > 0 && (
+            <div className="space-y-3">
               <p className="text-sm font-bold">
-                Start this challenge in your local Kubernetes cluster:
+                Complete the objectives below and submit your solution:
               </p>
-              <div className="bg-black text-green-400 p-3 rounded-lg neo-border-thick font-mono text-sm">
-                <span className="text-gray-500">$</span> kubeasy challenge start{" "}
-                {slug}
-              </div>
-            </>
-          ) : (
-            <>
-              <p className="text-sm font-bold">Submit your solution:</p>
-              <div className="bg-black text-green-400 p-3 rounded-lg neo-border-thick font-mono text-sm">
-                <span className="text-gray-500">$</span> kubeasy challenge
-                submit {slug}
-              </div>
-            </>
-          )}
 
-          {/* History button */}
-          {submissions.length > 0 && (
-            <Dialog open={showHistory} onOpenChange={setShowHistory}>
-              <DialogTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="neo-border font-bold"
-                >
-                  <Clock className="h-4 w-4 mr-2" />
-                  View History ({submissions.length})
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto neo-border-thick">
-                <DialogHeader>
-                  <DialogTitle className="text-2xl font-black">
-                    Submission History
-                  </DialogTitle>
-                  <DialogDescription>
-                    Previous attempts for this challenge
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-3 mt-4">
-                  {submissions.map((submission) => (
-                    <div
-                      key={submission.id}
-                      className="p-4 bg-secondary neo-border-thick flex items-center justify-between"
-                    >
-                      <span className="font-bold text-sm">
-                        {submission.timestamp
-                          ? new Date(submission.timestamp).toLocaleString()
-                          : "Unknown date"}
-                      </span>
-                      <span
-                        className={cn(
-                          "font-bold text-sm px-2 py-0.5 neo-border",
-                          submission.validated
-                            ? "bg-green-100 text-green-700"
-                            : "bg-red-100 text-red-700",
-                        )}
-                      >
-                        {submission.validated ? "Passed" : "Failed"}
-                      </span>
+              <div className="space-y-2">
+                {displayObjectives.map((obj) => (
+                  <div
+                    key={obj.id}
+                    className={cn(
+                      "flex items-start gap-3 p-3 rounded-lg neo-border",
+                      obj.status === true
+                        ? "bg-green-50"
+                        : obj.status === false
+                          ? "bg-red-50"
+                          : "bg-white",
+                    )}
+                  >
+                    <StatusIcon objStatus={obj.status} />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="font-bold">{obj.title}</p>
+                        <span
+                          className={cn(
+                            "text-xs font-semibold px-2 py-0.5 rounded-full",
+                            CATEGORY_COLORS[obj.category] ||
+                              "bg-gray-100 text-gray-700",
+                          )}
+                        >
+                          {CATEGORY_LABELS[obj.category] || obj.category}
+                        </span>
+                      </div>
+                      {obj.description && (
+                        <p className="text-sm text-foreground/70 mt-1">
+                          {obj.description}
+                        </p>
+                      )}
+                      {obj.message && (
+                        <p
+                          className={cn(
+                            "text-sm mt-2 font-medium",
+                            obj.status === true
+                              ? "text-green-700"
+                              : "text-red-600",
+                          )}
+                        >
+                          {obj.message}
+                        </p>
+                      )}
                     </div>
-                  ))}
-                </div>
-              </DialogContent>
-            </Dialog>
-          )}
-        </div>
+                  </div>
+                ))}
+              </div>
 
-        {/* No objectives (backward compat) */}
-        {!isLoading && displayObjectives.length === 0 && !hasAnySubmission && (
-          <p className="text-sm font-medium text-muted-foreground">
-            Submit your solution to see validation progress.
-          </p>
-        )}
-      </CardContent>
-    </Card>
+              {/* Last Updated */}
+              {hasAnySubmission &&
+                (validationStatus as LatestValidationStatusOutput | undefined)
+                  ?.timestamp && (
+                  <p className="text-xs text-muted-foreground text-right font-medium">
+                    Last updated:{" "}
+                    {new Date(
+                      String(
+                        (validationStatus as LatestValidationStatusOutput)
+                          .timestamp,
+                      ),
+                    ).toLocaleString()}
+                  </p>
+                )}
+            </div>
+          )}
+
+          {/* CLI Commands */}
+          <div className="space-y-3">
+            {isCompleted ? (
+              <>
+                <p className="text-sm font-bold">
+                  Clean up the resources with:
+                </p>
+                <div className="bg-black text-green-400 p-3 rounded-lg neo-border-thick font-mono text-sm">
+                  <span className="text-gray-500">$</span> kubeasy challenge
+                  clean {slug}
+                </div>
+              </>
+            ) : status === "not_started" ? (
+              <>
+                <p className="text-sm font-bold">
+                  Start this challenge in your local Kubernetes cluster:
+                </p>
+                <div className="bg-black text-green-400 p-3 rounded-lg neo-border-thick font-mono text-sm">
+                  <span className="text-gray-500">$</span> kubeasy challenge
+                  start {slug}
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-sm font-bold">Submit your solution:</p>
+                <div className="bg-black text-green-400 p-3 rounded-lg neo-border-thick font-mono text-sm">
+                  <span className="text-gray-500">$</span> kubeasy challenge
+                  submit {slug}
+                </div>
+              </>
+            )}
+
+            {/* History button */}
+            {submissions.length > 0 && (
+              <Dialog open={showHistory} onOpenChange={setShowHistory}>
+                <DialogTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="neo-border font-bold"
+                  >
+                    <Clock className="h-4 w-4 mr-2" />
+                    View History ({submissions.length})
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto neo-border-thick">
+                  <DialogHeader>
+                    <DialogTitle className="text-2xl font-black">
+                      Submission History
+                    </DialogTitle>
+                    <DialogDescription>
+                      Previous attempts for this challenge
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-3 mt-4">
+                    {submissions.map((submission) => (
+                      <div
+                        key={submission.id}
+                        className="p-4 bg-secondary neo-border-thick flex items-center justify-between"
+                      >
+                        <span className="font-bold text-sm">
+                          {submission.timestamp
+                            ? new Date(submission.timestamp).toLocaleString()
+                            : "Unknown date"}
+                        </span>
+                        <span
+                          className={cn(
+                            "font-bold text-sm px-2 py-0.5 neo-border",
+                            submission.validated
+                              ? "bg-green-100 text-green-700"
+                              : "bg-red-100 text-red-700",
+                          )}
+                        >
+                          {submission.validated ? "Passed" : "Failed"}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </DialogContent>
+              </Dialog>
+            )}
+          </div>
+
+          {/* No objectives (backward compat) */}
+          {!isLoading &&
+            displayObjectives.length === 0 &&
+            !hasAnySubmission && (
+              <p className="text-sm font-medium text-muted-foreground">
+                Submit your solution to see validation progress.
+              </p>
+            )}
+        </CardContent>
+      </Card>
+    </>
   );
 }

--- a/apps/web/src/hooks/use-challenge-celebration-sse.ts
+++ b/apps/web/src/hooks/use-challenge-celebration-sse.ts
@@ -1,11 +1,20 @@
-import type { ChallengeCompletedEventData } from "@kubeasy/api-schemas/sse-events";
-import { useEffect } from "react";
+import {
+  type ChallengeCompletedEventData,
+  ChallengeCompletedEventDataSchema,
+} from "@kubeasy/api-schemas/sse-events";
+import { useEffect, useRef } from "react";
 
 export function useChallengeCelebrationSSE(
   slug: string,
   enabled: boolean,
   onCompleted: (data: ChallengeCompletedEventData) => void,
 ) {
+  // Stable ref so the effect doesn't reconnect when the callback identity changes
+  const onCompletedRef = useRef(onCompleted);
+  useEffect(() => {
+    onCompletedRef.current = onCompleted;
+  });
+
   useEffect(() => {
     if (!enabled) return;
 
@@ -14,11 +23,11 @@ export function useChallengeCelebrationSSE(
     const es = new EventSource(url, { withCredentials: true });
 
     es.addEventListener("challenge-completed", (event) => {
-      try {
-        const data = JSON.parse(event.data) as ChallengeCompletedEventData;
-        onCompleted(data);
-      } catch {
-        // Ignore malformed events
+      const result = ChallengeCompletedEventDataSchema.safeParse(
+        JSON.parse(event.data),
+      );
+      if (result.success) {
+        onCompletedRef.current(result.data);
       }
     });
 
@@ -29,5 +38,5 @@ export function useChallengeCelebrationSSE(
     return () => {
       es.close();
     };
-  }, [slug, enabled, onCompleted]);
+  }, [slug, enabled]);
 }

--- a/apps/web/src/hooks/use-challenge-celebration-sse.ts
+++ b/apps/web/src/hooks/use-challenge-celebration-sse.ts
@@ -1,0 +1,33 @@
+import type { ChallengeCompletedEventData } from "@kubeasy/api-schemas/sse-events";
+import { useEffect } from "react";
+
+export function useChallengeCelebrationSSE(
+  slug: string,
+  enabled: boolean,
+  onCompleted: (data: ChallengeCompletedEventData) => void,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const apiBase = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
+    const url = `${apiBase}/api/sse/challenge/${slug}`;
+    const es = new EventSource(url, { withCredentials: true });
+
+    es.addEventListener("challenge-completed", (event) => {
+      try {
+        const data = JSON.parse(event.data) as ChallengeCompletedEventData;
+        onCompleted(data);
+      } catch {
+        // Ignore malformed events
+      }
+    });
+
+    es.addEventListener("error", () => {
+      // EventSource auto-reconnects on error — no manual retry needed.
+    });
+
+    return () => {
+      es.close();
+    };
+  }, [slug, enabled, onCompleted]);
+}

--- a/apps/web/src/hooks/use-invalidate-cache-sse.ts
+++ b/apps/web/src/hooks/use-invalidate-cache-sse.ts
@@ -1,13 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 
-/**
- * Subscribe to the generic cache-invalidation SSE channel.
- * On each "invalidate-cache" event, calls queryClient.invalidateQueries
- * with the received queryKey.
- *
- * @param enabled - Whether to connect (e.g., only when challenge is in_progress)
- */
 export function useInvalidateCacheSSE(enabled: boolean) {
   const queryClient = useQueryClient();
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,6 +14,7 @@ import { evlogErrorHandler } from "evlog/nitro/v3";
 import { type ReactNode, useEffect } from "react";
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
+import { useInvalidateCacheSSE } from "@/hooks/use-invalidate-cache-sse";
 import { identifyUser } from "@/lib/analytics";
 import { authClient } from "@/lib/auth-client";
 import globalsCss from "@/styles/globals.css?url";
@@ -92,6 +93,12 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
 });
 
+function CacheInvalidationSSE() {
+  const { data: session } = authClient.useSession();
+  useInvalidateCacheSSE(!!session);
+  return null;
+}
+
 function AnalyticsIdentity() {
   const { data: session } = authClient.useSession();
 
@@ -120,6 +127,7 @@ function RootComponent() {
   return (
     <RootDocument>
       <QueryClientProvider client={queryClient}>
+        <CacheInvalidationSSE />
         <AnalyticsIdentity />
         {!isLogin && <Header />}
         <main className={isLogin ? undefined : "pt-32 pb-20"}>

--- a/packages/api-schemas/package.json
+++ b/packages/api-schemas/package.json
@@ -14,7 +14,8 @@
     "./query-keys": "./src/query-keys.ts",
     "./onboarding": "./src/onboarding.ts",
     "./registry": "./src/registry.ts",
-    "./cli": "./src/cli.ts"
+    "./cli": "./src/cli.ts",
+    "./sse-events": "./src/sse-events.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/api-schemas/src/index.ts
+++ b/packages/api-schemas/src/index.ts
@@ -4,6 +4,7 @@ export * from "./cli";
 export * from "./email";
 export * from "./progress";
 export * from "./registry";
+export * from "./sse-events";
 export {
   type AuditEvent,
   AuditEventSchema,

--- a/packages/api-schemas/src/sse-events.ts
+++ b/packages/api-schemas/src/sse-events.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+const RankInfoSchema = z.object({
+  name: z.string(),
+  minXp: z.number().int(),
+  nextRankXp: z.number().int().nullable(),
+  progress: z.number().int(),
+});
+
+export const ChallengeCompletedEventDataSchema = z.object({
+  challengeSlug: z.string(),
+  difficulty: z.enum(["easy", "medium", "hard"]),
+  xpGain: z.object({
+    base: z.number().int(),
+    firstChallenge: z.number().int(),
+    streak: z.number().int(),
+    total: z.number().int(),
+  }),
+  isFirstChallenge: z.boolean(),
+  currentStreak: z.number().int(),
+  attemptsCount: z.number().int(),
+  commandsCount: z.number().int(),
+  leveledUp: z.boolean(),
+  prevRank: RankInfoSchema,
+  newRank: RankInfoSchema,
+});
+
+export type ChallengeCompletedEventData = z.infer<
+  typeof ChallengeCompletedEventDataSchema
+>;

--- a/packages/jobs/src/payloads.ts
+++ b/packages/jobs/src/payloads.ts
@@ -4,6 +4,7 @@ export interface ChallengeSubmissionPayload {
   userId: string;
   challengeSlug: string;
   difficulty: string;
+  prevTotalXp: number;
 }
 
 export interface XpAwardPayload {


### PR DESCRIPTION
## Contexte

Quand un utilisateur complète un challenge, l'UI ne lui donnait aucun feedback significatif : le texte de la carte « Your Mission » changeait discrètement, c'est tout. L'objectif était d'ajouter un moment de célébration avec un récap complet (XP, stats, rang) et des boutons de partage.

## Choix d'architecture

### Trigger : SSE dédié plutôt que polling ou localStorage

On aurait pu détecter la complétion côté frontend en observant le changement de statut (polling TanStack Query, ou comparaison dans un `useEffect`). On a préféré un **event SSE dédié** pour trois raisons :
1. Le payload peut transporter toutes les données de célébration en une seule fois (XP, rang avant/après, stats) sans round-trip supplémentaire.
2. L'event ne se rejoue pas au refresh — comportement voulu : le modal n'apparaît qu'au moment de la complétion réelle, pas à chaque visite.
3. C'est l'infrastructure déjà en place (Redis pub/sub → Hono `streamSSE`), pas de nouvelle dépendance.

### Canal dédié par challenge (`challenge:{userId}:{slug}`)

Le canal global `invalidate-cache:{userId}` existant aurait pu servir, mais cela aurait signifié que l'event de célébration d'un challenge B aurait pu déclencher le modal sur la page du challenge A si l'utilisateur avait deux onglets ouverts. On a donc ajouté un **canal par challenge** pour les events de célébration, et conservé le canal global pour les invalidations de cache.

### Émetteur : `challenge-submission.worker` (orchestrateur unique)

Le worker `xp-award` tourne 1 à 3 fois par submission (une fois par type de bonus XP). Le worker `challenge-submission` tourne exactement une fois par submission validée — c'est lui qui orchestre tout. C'est donc le bon endroit pour émettre l'event de célébration, après que tous les jobs XP ont été dispatchés (les valeurs sont calculées en mémoire, pas besoin d'attendre l'écriture en DB).

### Comptage de commandes via `jsonb_array_length(audit_events)`

On n'a pas de compteur de commandes shell — le CLI ne les transmet pas. En revanche, chaque submission inclut un champ `audit_events` (appels à l'API server Kubernetes). C'est un proxy raisonnable pour « combien de fois l'utilisateur a touché le cluster », labellisé « K8s Calls » dans l'UI pour ne pas induire en erreur.

### `getRankFromXp` extrait en helper pur

`calculateLevel(userId)` faisait un `SUM` en DB puis calculait le rang. Le worker avait besoin de calculer deux rangs (avant et après le gain XP) sans deux queries. On a extrait `getRankFromXp(totalXp: number)` — une fonction pure sur `RANK_THRESHOLDS` — que les deux consommateurs partagent.

### Montage du hook SSE dans `__root.tsx`

Le hook `useInvalidateCacheSSE` était dans `_protected.tsx` (layout route). Avec TanStack Start en mode SSR, les composants des layout routes ne montent pas côté client de la même façon — le hook ne s'abonnait pas. On a reproduit le pattern `AnalyticsIdentity` déjà utilisé dans `__root.tsx` : un composant `CacheInvalidationSSE` qui lit la session et appelle le hook, rendu dans le `QueryClientProvider` de la racine.

### Modal : une seule instance `Dialog` avec `open` prop

Le premier essai utilisait un early-return (`if (!payload) return null`). Radix UI remplace alors tout l'arbre du composant quand le state passe de `null` à une valeur, ce qui casse l'animation d'ouverture. La solution : **toujours rendre le même `<Dialog>`** avec `open={payload !== null}`, et mettre le `DialogContent` en conditionnel à l'intérieur.

## Ce qui change

| Fichier | Nature |
|---|---|
| `packages/api-schemas/src/sse-events.ts` | Nouveau — schéma Zod du payload `challenge-completed` |
| `apps/api/services/xp/calculateLevel.ts` | Extraction de `getRankFromXp` (helper pur) |
| `apps/api/routes/sse.ts` | Nouveau endpoint `/challenge/:slug`, support des event names dynamiques |
| `apps/api/routes/progress.ts` | Publish SSE sur `POST /:slug/start` (mise à jour temps réel au démarrage CLI) |
| `apps/api/workers/challenge-submission.worker.ts` | Émission de l'event `challenge-completed` |
| `apps/web/hooks/use-challenge-celebration-sse.ts` | Nouveau hook SSE per-challenge |
| `apps/web/hooks/use-invalidate-cache-sse.ts` | Nettoyage, suppression du callback `onChallengeCompleted` |
| `apps/web/routes/__root.tsx` | Ajout de `CacheInvalidationSSE` (fix montage hook) |
| `apps/web/components/challenge-completion-modal.tsx` | Nouveau — modal de célébration |
| `apps/web/components/challenge-mission.tsx` | Câblage du state de célébration et du hook |

## Test plan

- [ ] `kubeasy challenge start <slug>` → la page passe de « not started » à « in progress » sans refresh
- [ ] Soumettre une solution valide → event `challenge-completed` reçu via SSE → modal s'ouvre avec confettis et stats correctes
- [ ] Vérifier le breakdown XP (base + first-challenge bonus + streak bonus)
- [ ] Vérifier la bannière level-up quand l'utilisateur franchit un seuil de rang
- [ ] Boutons de partage : X, LinkedIn, Bluesky ouvrent les intent URLs dans un nouvel onglet ; Copy link copie l'URL + toast Sonner
- [ ] Fermer le modal → pas de ré-ouverture au refresh (trigger event-only)
- [ ] `pnpm typecheck` passe sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)