### PR TITLE
feat(api): add admin analytics routes for funnel and challenge stats

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2563,7 +2563,7 @@
                           "uniqueUsers": {
                             "type": "number"
                           },
-                          "completions": {
+                          "validatedSubmissions": {
                             "type": "number"
                           },
                           "completionRate": {
@@ -2595,7 +2595,7 @@
                           "challengeSlug",
                           "totalAttempts",
                           "uniqueUsers",
-                          "completions",
+                          "validatedSubmissions",
                           "completionRate",
                           "avgAttempts",
                           "topFailingObjectives"

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2567,10 +2567,13 @@
                             "type": "number"
                           },
                           "completionRate": {
-                            "type": "number"
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
                           },
                           "avgAttempts": {
-                            "type": "number"
+                            "type": "number",
+                            "minimum": 0
                           },
                           "topFailingObjectives": {
                             "type": "array",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2487,6 +2487,132 @@
         }
       }
     },
+    "/api/admin/analytics/funnel": {
+      "get": {
+        "operationId": "getApiAdminAnalyticsFunnel",
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Signup → started → completed funnel",
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funnel stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalUsers": {
+                      "type": "number"
+                    },
+                    "usersStarted": {
+                      "type": "number"
+                    },
+                    "usersCompleted": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "totalUsers",
+                    "usersStarted",
+                    "usersCompleted"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/analytics/challenges": {
+      "get": {
+        "operationId": "getApiAdminAnalyticsChallenges",
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Aggregated stats per challenge",
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Challenge analytics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "challenges": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "challengeSlug": {
+                            "type": "string"
+                          },
+                          "totalAttempts": {
+                            "type": "number"
+                          },
+                          "uniqueUsers": {
+                            "type": "number"
+                          },
+                          "completions": {
+                            "type": "number"
+                          },
+                          "completionRate": {
+                            "type": "number"
+                          },
+                          "avgAttempts": {
+                            "type": "number"
+                          },
+                          "topFailingObjectives": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "failCount": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "failCount"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "challengeSlug",
+                          "totalAttempts",
+                          "uniqueUsers",
+                          "completions",
+                          "completionRate",
+                          "avgAttempts",
+                          "topFailingObjectives"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "challenges"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/challenges": {
       "get": {
         "operationId": "getApiAdminChallenges",

--- a/apps/api/src/routes/admin/analytics.ts
+++ b/apps/api/src/routes/admin/analytics.ts
@@ -1,10 +1,12 @@
-import { countDistinct, sql } from "drizzle-orm";
+import { countDistinct, ne, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 import { z } from "zod";
 import { db } from "../../db";
 import { user, userProgress, userSubmission } from "../../db/schema";
 import { sessionSecurity } from "../../lib/openapi-shared";
+import { redis } from "../../lib/redis";
+import { slidingWindowRateLimit } from "../../middleware/rate-limit";
 import type { AppEnv } from "../../middleware/session";
 
 const FunnelOutputSchema = z.object({
@@ -22,7 +24,7 @@ const ChallengeStatsItemSchema = z.object({
   challengeSlug: z.string(),
   totalAttempts: z.number(),
   uniqueUsers: z.number(),
-  completions: z.number(),
+  validatedSubmissions: z.number(),
   completionRate: z.number(),
   avgAttempts: z.number(),
   topFailingObjectives: z.array(FailingObjectiveSchema),
@@ -30,6 +32,22 @@ const ChallengeStatsItemSchema = z.object({
 
 const ChallengesAnalyticsOutputSchema = z.object({
   challenges: z.array(ChallengeStatsItemSchema),
+});
+
+// Schema for validating raw JSONB rows from failing objectives query
+const failingObjectiveRowSchema = z.object({
+  challenge_slug: z.string(),
+  key: z
+    .string()
+    .max(256)
+    .regex(/^[\w.-]+$/),
+  fail_count: z.coerce.number(),
+});
+
+const analyticsRateLimit = slidingWindowRateLimit(redis, {
+  windowMs: 60_000,
+  max: 30,
+  keyFn: (c) => `admin-analytics:${c.get("user")?.id ?? "unknown"}`,
 });
 
 export const adminAnalytics = new Hono<AppEnv>()
@@ -48,6 +66,7 @@ export const adminAnalytics = new Hono<AppEnv>()
         },
       },
     }),
+    analyticsRateLimit,
     async (c) => {
       const [totalRow] = await db
         .select({ totalUsers: sql<number>`COUNT(*)` })
@@ -58,7 +77,7 @@ export const adminAnalytics = new Hono<AppEnv>()
           usersStarted: countDistinct(userProgress.userId),
         })
         .from(userProgress)
-        .where(sql`${userProgress.status} != 'not_started'`);
+        .where(ne(userProgress.status, "not_started"));
 
       const [completedRow] = await db
         .select({
@@ -91,6 +110,7 @@ export const adminAnalytics = new Hono<AppEnv>()
         },
       },
     }),
+    analyticsRateLimit,
     async (c) => {
       // Aggregate base stats per challenge
       const baseStats = await db
@@ -98,10 +118,11 @@ export const adminAnalytics = new Hono<AppEnv>()
           challengeSlug: userSubmission.challengeSlug,
           totalAttempts: sql<number>`COUNT(*)`,
           uniqueUsers: countDistinct(userSubmission.userId),
-          completions: sql<number>`COUNT(*) FILTER (WHERE ${userSubmission.validated} = true)`,
+          validatedSubmissions: sql<number>`COUNT(DISTINCT ${userSubmission.userId}) FILTER (WHERE ${userSubmission.validated} = true)`,
         })
         .from(userSubmission)
-        .groupBy(userSubmission.challengeSlug);
+        .groupBy(userSubmission.challengeSlug)
+        .orderBy(userSubmission.challengeSlug);
 
       // Get top failing objectives per challenge using jsonb_array_elements
       const failingObjectivesRows = await db.execute(sql`
@@ -118,15 +139,15 @@ export const adminAnalytics = new Hono<AppEnv>()
       `);
 
       // Group failing objectives by challenge slug, keep top 5
+      // Validate each row with Zod before processing
       const failingBySlug = new Map<
         string,
         Array<{ key: string; failCount: number }>
       >();
-      for (const row of failingObjectivesRows.rows as Array<{
-        challenge_slug: string;
-        key: string;
-        fail_count: string;
-      }>) {
+      for (const row of failingObjectivesRows.rows
+        .map((r) => failingObjectiveRowSchema.safeParse(r))
+        .filter((r) => r.success)
+        .map((r) => r.data)) {
         const existing = failingBySlug.get(row.challenge_slug) ?? [];
         if (existing.length < 5) {
           existing.push({ key: row.key, failCount: Number(row.fail_count) });
@@ -137,17 +158,17 @@ export const adminAnalytics = new Hono<AppEnv>()
       const challenges = baseStats.map((row) => {
         const totalAttempts = Number(row.totalAttempts);
         const uniqueUsers = Number(row.uniqueUsers);
-        const completions = Number(row.completions);
-        const completionRate = uniqueUsers > 0 ? completions / uniqueUsers : 0;
+        const validatedSubmissions = Number(row.validatedSubmissions);
+        const completionRate =
+          uniqueUsers > 0 ? validatedSubmissions / uniqueUsers : 0;
         const avgAttempts = uniqueUsers > 0 ? totalAttempts / uniqueUsers : 0;
-        const topFailingObjectives =
-          failingBySlug.get(row.challengeSlug) ?? [];
+        const topFailingObjectives = failingBySlug.get(row.challengeSlug) ?? [];
 
         return {
           challengeSlug: row.challengeSlug,
           totalAttempts,
           uniqueUsers,
-          completions,
+          validatedSubmissions,
           completionRate,
           avgAttempts,
           topFailingObjectives,

--- a/apps/api/src/routes/admin/analytics.ts
+++ b/apps/api/src/routes/admin/analytics.ts
@@ -1,4 +1,4 @@
-import { countDistinct, ne, sql } from "drizzle-orm";
+import { countDistinct, eq, ne, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 import { z } from "zod";
@@ -25,8 +25,8 @@ const ChallengeStatsItemSchema = z.object({
   totalAttempts: z.number(),
   uniqueUsers: z.number(),
   validatedSubmissions: z.number(),
-  completionRate: z.number(),
-  avgAttempts: z.number(),
+  completionRate: z.number().min(0).max(1),
+  avgAttempts: z.number().min(0),
   topFailingObjectives: z.array(FailingObjectiveSchema),
 });
 
@@ -47,7 +47,8 @@ const failingObjectiveRowSchema = z.object({
 const analyticsRateLimit = slidingWindowRateLimit(redis, {
   windowMs: 60_000,
   max: 30,
-  keyFn: (c) => `admin-analytics:${c.get("user")?.id ?? "unknown"}`,
+  keyFn: (c) =>
+    `admin-analytics:${c.get("user")?.id ?? c.req.header("x-forwarded-for") ?? "unknown"}`,
 });
 
 export const adminAnalytics = new Hono<AppEnv>()
@@ -84,7 +85,7 @@ export const adminAnalytics = new Hono<AppEnv>()
           usersCompleted: countDistinct(userProgress.userId),
         })
         .from(userProgress)
-        .where(sql`${userProgress.status} = 'completed'`);
+        .where(eq(userProgress.status, "completed"));
 
       return c.json({
         totalUsers: Number(totalRow?.totalUsers ?? 0),
@@ -144,10 +145,16 @@ export const adminAnalytics = new Hono<AppEnv>()
         string,
         Array<{ key: string; failCount: number }>
       >();
-      for (const row of failingObjectivesRows.rows
-        .map((r) => failingObjectiveRowSchema.safeParse(r))
-        .filter((r) => r.success)
-        .map((r) => r.data)) {
+      for (const parsed of failingObjectivesRows.rows.map((r) =>
+        failingObjectiveRowSchema.safeParse(r),
+      )) {
+        if (!parsed.success) {
+          c.get("log").warn("analytics: dropping malformed objective row", {
+            error: String(parsed.error),
+          });
+          continue;
+        }
+        const row = parsed.data;
         const existing = failingBySlug.get(row.challenge_slug) ?? [];
         if (existing.length < 5) {
           existing.push({ key: row.key, failCount: Number(row.fail_count) });

--- a/apps/api/src/routes/admin/analytics.ts
+++ b/apps/api/src/routes/admin/analytics.ts
@@ -1,0 +1,159 @@
+import { countDistinct, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { describeRoute, resolver } from "hono-openapi";
+import { z } from "zod";
+import { db } from "../../db";
+import { user, userProgress, userSubmission } from "../../db/schema";
+import { sessionSecurity } from "../../lib/openapi-shared";
+import type { AppEnv } from "../../middleware/session";
+
+const FunnelOutputSchema = z.object({
+  totalUsers: z.number(),
+  usersStarted: z.number(),
+  usersCompleted: z.number(),
+});
+
+const FailingObjectiveSchema = z.object({
+  key: z.string(),
+  failCount: z.number(),
+});
+
+const ChallengeStatsItemSchema = z.object({
+  challengeSlug: z.string(),
+  totalAttempts: z.number(),
+  uniqueUsers: z.number(),
+  completions: z.number(),
+  completionRate: z.number(),
+  avgAttempts: z.number(),
+  topFailingObjectives: z.array(FailingObjectiveSchema),
+});
+
+const ChallengesAnalyticsOutputSchema = z.object({
+  challenges: z.array(ChallengeStatsItemSchema),
+});
+
+export const adminAnalytics = new Hono<AppEnv>()
+  .get(
+    "/funnel",
+    describeRoute({
+      tags: ["Admin"],
+      summary: "Signup → started → completed funnel",
+      security: sessionSecurity,
+      responses: {
+        200: {
+          description: "Funnel stats",
+          content: {
+            "application/json": { schema: resolver(FunnelOutputSchema) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const [totalRow] = await db
+        .select({ totalUsers: sql<number>`COUNT(*)` })
+        .from(user);
+
+      const [startedRow] = await db
+        .select({
+          usersStarted: countDistinct(userProgress.userId),
+        })
+        .from(userProgress)
+        .where(sql`${userProgress.status} != 'not_started'`);
+
+      const [completedRow] = await db
+        .select({
+          usersCompleted: countDistinct(userProgress.userId),
+        })
+        .from(userProgress)
+        .where(sql`${userProgress.status} = 'completed'`);
+
+      return c.json({
+        totalUsers: Number(totalRow?.totalUsers ?? 0),
+        usersStarted: Number(startedRow?.usersStarted ?? 0),
+        usersCompleted: Number(completedRow?.usersCompleted ?? 0),
+      });
+    },
+  )
+  .get(
+    "/challenges",
+    describeRoute({
+      tags: ["Admin"],
+      summary: "Aggregated stats per challenge",
+      security: sessionSecurity,
+      responses: {
+        200: {
+          description: "Challenge analytics",
+          content: {
+            "application/json": {
+              schema: resolver(ChallengesAnalyticsOutputSchema),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      // Aggregate base stats per challenge
+      const baseStats = await db
+        .select({
+          challengeSlug: userSubmission.challengeSlug,
+          totalAttempts: sql<number>`COUNT(*)`,
+          uniqueUsers: countDistinct(userSubmission.userId),
+          completions: sql<number>`COUNT(*) FILTER (WHERE ${userSubmission.validated} = true)`,
+        })
+        .from(userSubmission)
+        .groupBy(userSubmission.challengeSlug);
+
+      // Get top failing objectives per challenge using jsonb_array_elements
+      const failingObjectivesRows = await db.execute(sql`
+        SELECT
+          s.challenge_slug,
+          obj->>'objectiveKey' AS key,
+          COUNT(*) AS fail_count
+        FROM user_submission s,
+             jsonb_array_elements(s.objectives) AS obj
+        WHERE (obj->>'passed')::boolean = false
+          AND s.objectives IS NOT NULL
+        GROUP BY s.challenge_slug, obj->>'objectiveKey'
+        ORDER BY s.challenge_slug, COUNT(*) DESC
+      `);
+
+      // Group failing objectives by challenge slug, keep top 5
+      const failingBySlug = new Map<
+        string,
+        Array<{ key: string; failCount: number }>
+      >();
+      for (const row of failingObjectivesRows.rows as Array<{
+        challenge_slug: string;
+        key: string;
+        fail_count: string;
+      }>) {
+        const existing = failingBySlug.get(row.challenge_slug) ?? [];
+        if (existing.length < 5) {
+          existing.push({ key: row.key, failCount: Number(row.fail_count) });
+        }
+        failingBySlug.set(row.challenge_slug, existing);
+      }
+
+      const challenges = baseStats.map((row) => {
+        const totalAttempts = Number(row.totalAttempts);
+        const uniqueUsers = Number(row.uniqueUsers);
+        const completions = Number(row.completions);
+        const completionRate = uniqueUsers > 0 ? completions / uniqueUsers : 0;
+        const avgAttempts = uniqueUsers > 0 ? totalAttempts / uniqueUsers : 0;
+        const topFailingObjectives =
+          failingBySlug.get(row.challengeSlug) ?? [];
+
+        return {
+          challengeSlug: row.challengeSlug,
+          totalAttempts,
+          uniqueUsers,
+          completions,
+          completionRate,
+          avgAttempts,
+          topFailingObjectives,
+        };
+      });
+
+      return c.json({ challenges });
+    },
+  );

--- a/apps/api/src/routes/admin/index.ts
+++ b/apps/api/src/routes/admin/index.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono";
 import { requireAdmin } from "../../middleware/admin";
 import type { AppEnv } from "../../middleware/session";
+import { adminAnalytics } from "./analytics";
 import { adminChallenges } from "./challenges";
 import { adminUsers } from "./users";
 
 export const admin = new Hono<AppEnv>()
   .use("/*", requireAdmin)
+  .route("/analytics", adminAnalytics)
   .route("/challenges", adminChallenges)
   .route("/users", adminUsers);


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/analytics/funnel` returning signup → started → completed user counts queried directly from PostgreSQL
- Adds `GET /api/admin/analytics/challenges` returning per-challenge aggregated stats: total attempts, unique users, completions, completion rate, avg attempts, and top 5 failing objectives (via `jsonb_array_elements`)
- Registers the new router in `apps/api/src/routes/admin/index.ts`

Part of the PostHog backend removal (ADR-0011) — analytics are now served from the DB instead of PostHog.

Closes #163

## Test plan

- [ ] `pnpm typecheck` passes (verified locally — 7/7 tasks successful)
- [ ] `GET /api/admin/analytics/funnel` returns `{ totalUsers, usersStarted, usersCompleted }` for an admin session
- [ ] `GET /api/admin/analytics/challenges` returns the `challenges` array with correct aggregates
- [ ] Non-admin requests are rejected by `requireAdmin` middleware (401/403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)