### PR TITLE
feat(api): add admin analytics CLI events stats route

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2616,6 +2616,104 @@
         }
       }
     },
+    "/api/admin/analytics/cli": {
+      "get": {
+        "operationId": "getApiAdminAnalyticsCli",
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Aggregated stats for CLI events",
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CLI analytics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalEvents": {
+                      "type": "number"
+                    },
+                    "uniqueUsers": {
+                      "type": "number"
+                    },
+                    "byVersion": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "cliVersion": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "cliVersion",
+                          "count"
+                        ]
+                      }
+                    },
+                    "byOs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "os": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "os",
+                          "count"
+                        ]
+                      }
+                    },
+                    "byEventType": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "eventType": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "eventType",
+                          "count"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "totalEvents",
+                    "uniqueUsers",
+                    "byVersion",
+                    "byOs",
+                    "byEventType"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests"
+          }
+        }
+      }
+    },
     "/api/admin/challenges": {
       "get": {
         "operationId": "getApiAdminChallenges",

--- a/apps/api/src/routes/admin/analytics.ts
+++ b/apps/api/src/routes/admin/analytics.ts
@@ -229,10 +229,35 @@ export const adminAnalytics = new Hono<AppEnv>()
     analyticsRateLimit,
     async (c) => {
       const [[totalsRow], byVersion, byOs, byEventType] = await Promise.all([
-        db.select({ totalEvents: sql<number>`COUNT(*)`, uniqueUsers: countDistinct(cliEvent.userId) }).from(cliEvent),
-        db.select({ cliVersion: cliEvent.cliVersion, count: sql<number>`COUNT(*)` }).from(cliEvent).groupBy(cliEvent.cliVersion).orderBy(desc(sql`COUNT(*)`)),
-        db.select({ os: cliEvent.os, count: sql<number>`COUNT(*)` }).from(cliEvent).groupBy(cliEvent.os).orderBy(desc(sql`COUNT(*)`)),
-        db.select({ eventType: cliEvent.eventType, count: sql<number>`COUNT(*)` }).from(cliEvent).groupBy(cliEvent.eventType).orderBy(desc(sql`COUNT(*)`)),
+        db
+          .select({
+            totalEvents: sql<number>`COUNT(*)`,
+            uniqueUsers: countDistinct(cliEvent.userId),
+          })
+          .from(cliEvent),
+        db
+          .select({
+            cliVersion: cliEvent.cliVersion,
+            count: sql<number>`COUNT(*)`,
+          })
+          .from(cliEvent)
+          .groupBy(cliEvent.cliVersion)
+          .orderBy(desc(sql`COUNT(*)`))
+          .limit(100),
+        db
+          .select({ os: cliEvent.os, count: sql<number>`COUNT(*)` })
+          .from(cliEvent)
+          .groupBy(cliEvent.os)
+          .orderBy(desc(sql`COUNT(*)`))
+          .limit(100),
+        db
+          .select({
+            eventType: cliEvent.eventType,
+            count: sql<number>`COUNT(*)`,
+          })
+          .from(cliEvent)
+          .groupBy(cliEvent.eventType)
+          .orderBy(desc(sql`COUNT(*)`)),
       ]);
 
       return c.json({

--- a/apps/api/src/routes/admin/analytics.ts
+++ b/apps/api/src/routes/admin/analytics.ts
@@ -1,9 +1,9 @@
-import { countDistinct, eq, ne, sql } from "drizzle-orm";
+import { countDistinct, desc, eq, ne, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 import { z } from "zod";
 import { db } from "../../db";
-import { user, userProgress, userSubmission } from "../../db/schema";
+import { cliEvent, user, userProgress, userSubmission } from "../../db/schema";
 import { sessionSecurity } from "../../lib/openapi-shared";
 import { redis } from "../../lib/redis";
 import { slidingWindowRateLimit } from "../../middleware/rate-limit";
@@ -42,6 +42,29 @@ const failingObjectiveRowSchema = z.object({
     .max(256)
     .regex(/^[\w.-]+$/),
   fail_count: z.coerce.number(),
+});
+
+const CliVersionCountSchema = z.object({
+  cliVersion: z.string(),
+  count: z.number(),
+});
+
+const CliOsCountSchema = z.object({
+  os: z.string(),
+  count: z.number(),
+});
+
+const CliEventTypeCountSchema = z.object({
+  eventType: z.string(),
+  count: z.number(),
+});
+
+const CliAnalyticsOutputSchema = z.object({
+  totalEvents: z.number(),
+  uniqueUsers: z.number(),
+  byVersion: z.array(CliVersionCountSchema),
+  byOs: z.array(CliOsCountSchema),
+  byEventType: z.array(CliEventTypeCountSchema),
 });
 
 const analyticsRateLimit = slidingWindowRateLimit(redis, {
@@ -183,5 +206,77 @@ export const adminAnalytics = new Hono<AppEnv>()
       });
 
       return c.json({ challenges });
+    },
+  )
+  .get(
+    "/cli",
+    describeRoute({
+      tags: ["Admin"],
+      summary: "Aggregated stats for CLI events",
+      security: sessionSecurity,
+      responses: {
+        200: {
+          description: "CLI analytics",
+          content: {
+            "application/json": {
+              schema: resolver(CliAnalyticsOutputSchema),
+            },
+          },
+        },
+        429: { description: "Too Many Requests" },
+      },
+    }),
+    analyticsRateLimit,
+    async (c) => {
+      const [totalsRow] = await db
+        .select({
+          totalEvents: sql<number>`COUNT(*)`,
+          uniqueUsers: countDistinct(cliEvent.userId),
+        })
+        .from(cliEvent);
+
+      const byVersion = await db
+        .select({
+          cliVersion: cliEvent.cliVersion,
+          count: sql<number>`COUNT(*)`,
+        })
+        .from(cliEvent)
+        .groupBy(cliEvent.cliVersion)
+        .orderBy(desc(sql`COUNT(*)`));
+
+      const byOs = await db
+        .select({
+          os: cliEvent.os,
+          count: sql<number>`COUNT(*)`,
+        })
+        .from(cliEvent)
+        .groupBy(cliEvent.os)
+        .orderBy(desc(sql`COUNT(*)`));
+
+      const byEventType = await db
+        .select({
+          eventType: cliEvent.eventType,
+          count: sql<number>`COUNT(*)`,
+        })
+        .from(cliEvent)
+        .groupBy(cliEvent.eventType)
+        .orderBy(desc(sql`COUNT(*)`));
+
+      return c.json({
+        totalEvents: Number(totalsRow?.totalEvents ?? 0),
+        uniqueUsers: Number(totalsRow?.uniqueUsers ?? 0),
+        byVersion: byVersion.map((r) => ({
+          cliVersion: r.cliVersion,
+          count: Number(r.count),
+        })),
+        byOs: byOs.map((r) => ({
+          os: r.os,
+          count: Number(r.count),
+        })),
+        byEventType: byEventType.map((r) => ({
+          eventType: r.eventType,
+          count: Number(r.count),
+        })),
+      });
     },
   );

--- a/apps/api/src/routes/admin/analytics.ts
+++ b/apps/api/src/routes/admin/analytics.ts
@@ -228,39 +228,12 @@ export const adminAnalytics = new Hono<AppEnv>()
     }),
     analyticsRateLimit,
     async (c) => {
-      const [totalsRow] = await db
-        .select({
-          totalEvents: sql<number>`COUNT(*)`,
-          uniqueUsers: countDistinct(cliEvent.userId),
-        })
-        .from(cliEvent);
-
-      const byVersion = await db
-        .select({
-          cliVersion: cliEvent.cliVersion,
-          count: sql<number>`COUNT(*)`,
-        })
-        .from(cliEvent)
-        .groupBy(cliEvent.cliVersion)
-        .orderBy(desc(sql`COUNT(*)`));
-
-      const byOs = await db
-        .select({
-          os: cliEvent.os,
-          count: sql<number>`COUNT(*)`,
-        })
-        .from(cliEvent)
-        .groupBy(cliEvent.os)
-        .orderBy(desc(sql`COUNT(*)`));
-
-      const byEventType = await db
-        .select({
-          eventType: cliEvent.eventType,
-          count: sql<number>`COUNT(*)`,
-        })
-        .from(cliEvent)
-        .groupBy(cliEvent.eventType)
-        .orderBy(desc(sql`COUNT(*)`));
+      const [[totalsRow], byVersion, byOs, byEventType] = await Promise.all([
+        db.select({ totalEvents: sql<number>`COUNT(*)`, uniqueUsers: countDistinct(cliEvent.userId) }).from(cliEvent),
+        db.select({ cliVersion: cliEvent.cliVersion, count: sql<number>`COUNT(*)` }).from(cliEvent).groupBy(cliEvent.cliVersion).orderBy(desc(sql`COUNT(*)`)),
+        db.select({ os: cliEvent.os, count: sql<number>`COUNT(*)` }).from(cliEvent).groupBy(cliEvent.os).orderBy(desc(sql`COUNT(*)`)),
+        db.select({ eventType: cliEvent.eventType, count: sql<number>`COUNT(*)` }).from(cliEvent).groupBy(cliEvent.eventType).orderBy(desc(sql`COUNT(*)`)),
+      ]);
 
       return c.json({
         totalEvents: Number(totalsRow?.totalEvents ?? 0),


### PR DESCRIPTION
## Summary

- Adds `GET /analytics/cli` route under the admin analytics router
- Returns `totalEvents`, `uniqueUsers`, `byVersion`, `byOs`, and `byEventType` aggregates from the `cli_events` table
- Follows the same `describeRoute` + Zod schema + `resolver()` pattern as existing analytics routes, with 429 documented

## Test plan

- [ ] Hit `GET /api/admin/analytics/cli` with an admin session and verify the response shape matches the schema
- [ ] Confirm non-admin requests are rejected (enforced by the parent router's `requireAdmin` middleware)
- [ ] Confirm rate-limiting returns 429 after 30 requests within 60 seconds

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)