### PR TITLE
feat(web): challenge timeline with kubectl audit history

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1201,6 +1201,65 @@
                           "timestamp": {
                             "type": "string",
                             "description": "ISO 8601 date string"
+                          },
+                          "attemptNumber": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "auditEvents": {
+                            "anyOf": [
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "timestamp": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                    },
+                                    "verb": {
+                                      "type": "string",
+                                      "maxLength": 64
+                                    },
+                                    "resource": {
+                                      "type": "string",
+                                      "maxLength": 128
+                                    },
+                                    "subresource": {
+                                      "type": "string",
+                                      "maxLength": 128
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "maxLength": 253
+                                    },
+                                    "namespace": {
+                                      "type": "string",
+                                      "maxLength": 63
+                                    },
+                                    "userAgent": {
+                                      "type": "string",
+                                      "maxLength": 512
+                                    },
+                                    "responseCode": {
+                                      "type": "integer",
+                                      "minimum": 100,
+                                      "maximum": 599
+                                    }
+                                  },
+                                  "required": [
+                                    "timestamp",
+                                    "verb",
+                                    "resource"
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
                         },
                         "required": [

--- a/apps/web/src/components/challenge-mission.tsx
+++ b/apps/web/src/components/challenge-mission.tsx
@@ -1,24 +1,8 @@
 import type { ChallengeCompletedEventData } from "@kubeasy/api-schemas/sse-events";
-import { Button } from "@kubeasy/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@kubeasy/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@kubeasy/ui/dialog";
 import { useQuery } from "@tanstack/react-query";
 import type { InferResponseType } from "hono/client";
-import {
-  CheckCircle2,
-  Circle,
-  Clock,
-  Loader2,
-  Target,
-  XCircle,
-} from "lucide-react";
+import { CheckCircle2, Circle, Loader2, Target, XCircle } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { ChallengeCompletionModal } from "@/components/challenge-completion-modal";
 import { useChallengeCelebrationSSE } from "@/hooks/use-challenge-celebration-sse";
@@ -27,7 +11,6 @@ import {
   challengeObjectivesOptions,
   challengeStatusOptions,
   latestValidationOptions,
-  submissionsOptions,
 } from "@/lib/query-options";
 import type { rpc } from "@/lib/rpc";
 import { cn } from "@/lib/utils";
@@ -36,10 +19,6 @@ import { cn } from "@/lib/utils";
 // We filter on `200` to drop the 404 error variants from the union.
 type LatestValidationStatusOutput = InferResponseType<
   (typeof rpc.submissions)[":slug"]["latest"]["$get"],
-  200
->;
-type SubmissionsOutput = InferResponseType<
-  (typeof rpc.submissions)[":slug"]["$get"],
   200
 >;
 
@@ -74,7 +53,6 @@ interface DisplayObjective {
 }
 
 export function ChallengeMission({ slug }: ChallengeMissionProps) {
-  const [showHistory, setShowHistory] = useState(false);
   const [celebrationPayload, setCelebrationPayload] =
     useState<ChallengeCompletedEventData | null>(null);
 
@@ -95,11 +73,6 @@ export function ChallengeMission({ slug }: ChallengeMissionProps) {
 
   const { data: validationStatus, isLoading: isLoadingValidation } = useQuery({
     ...latestValidationOptions(slug),
-    enabled: isAuthenticated,
-  });
-
-  const { data: submissionsData } = useQuery({
-    ...submissionsOptions(slug),
     enabled: isAuthenticated,
   });
 
@@ -180,10 +153,6 @@ export function ChallengeMission({ slug }: ChallengeMissionProps) {
     }
     return <XCircle className="h-5 w-5 text-red-600 flex-shrink-0" />;
   };
-
-  // Get submissions array safely
-  const submissions =
-    (submissionsData as SubmissionsOutput | undefined)?.submissions ?? [];
 
   return (
     <>
@@ -330,56 +299,6 @@ export function ChallengeMission({ slug }: ChallengeMissionProps) {
                   submit {slug}
                 </div>
               </>
-            )}
-
-            {/* History button */}
-            {submissions.length > 0 && (
-              <Dialog open={showHistory} onOpenChange={setShowHistory}>
-                <DialogTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="neo-border font-bold"
-                  >
-                    <Clock className="h-4 w-4 mr-2" />
-                    View History ({submissions.length})
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto neo-border-thick">
-                  <DialogHeader>
-                    <DialogTitle className="text-2xl font-black">
-                      Submission History
-                    </DialogTitle>
-                    <DialogDescription>
-                      Previous attempts for this challenge
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="space-y-3 mt-4">
-                    {submissions.map((submission) => (
-                      <div
-                        key={submission.id}
-                        className="p-4 bg-secondary neo-border-thick flex items-center justify-between"
-                      >
-                        <span className="font-bold text-sm">
-                          {submission.timestamp
-                            ? new Date(submission.timestamp).toLocaleString()
-                            : "Unknown date"}
-                        </span>
-                        <span
-                          className={cn(
-                            "font-bold text-sm px-2 py-0.5 neo-border",
-                            submission.validated
-                              ? "bg-green-100 text-green-700"
-                              : "bg-red-100 text-red-700",
-                          )}
-                        >
-                          {submission.validated ? "Passed" : "Failed"}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </DialogContent>
-              </Dialog>
             )}
           </div>
 

--- a/apps/web/src/components/challenge-timeline.tsx
+++ b/apps/web/src/components/challenge-timeline.tsx
@@ -115,14 +115,13 @@ function TimelineRow({
   isLast: boolean;
 }) {
   const [hovered, setHovered] = useState(false);
-  const isAudit = item.type === "audit";
 
   return (
     // relative mb-2: each row is its own block, spine is absolute behind
     <div
       className={cn(
         "relative flex items-center gap-3",
-        isLast ? "" : isAudit ? "mb-1" : "mb-2",
+        isLast ? "" : item.type === "audit" ? "mb-1" : "mb-2",
       )}
     >
       {/* Marker: z-10 sits on top of the absolute spine */}
@@ -282,7 +281,9 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
         timestamp: new Date(sub.timestamp),
         validated: sub.validated,
         objectives: sub.objectives,
-        // Fall back to sequential index for old submissions without attemptNumber
+        // Fall back to sequential index for old submissions without attemptNumber.
+        // This counts from 1 within the current session window, so after a reset
+        // an old submission shows "Submit #1" rather than the true global attempt number.
         attemptNumber: sub.attemptNumber ?? submissionIndex,
       });
     }

--- a/apps/web/src/components/challenge-timeline.tsx
+++ b/apps/web/src/components/challenge-timeline.tsx
@@ -1,6 +1,5 @@
 import type { GetStatusOutput } from "@kubeasy/api-schemas/progress";
 import type {
-  AuditEvent,
   Objective,
   SubmissionRecord,
 } from "@kubeasy/api-schemas/submissions";
@@ -243,14 +242,15 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
 
   const status = statusData?.status ?? "not_started";
 
-  const timelineItems = useMemo((): TimelineItem[] => {
+  const { items: timelineItems, auditCount } = useMemo(() => {
     const s = statusData as GetStatusOutput | undefined;
-    if (!s?.startedAt) return [];
+    if (!s?.startedAt) return { items: [], auditCount: 0 };
 
     const items: TimelineItem[] = [];
 
     items.push({ type: "start", timestamp: new Date(s.startedAt) });
 
+    // SubmissionsOutput uses JSONValue for JSONB columns; cast to SubmissionRecord[] for proper typing
     const submissions =
       ((submissionsData as SubmissionsOutput | undefined)
         ?.submissions as SubmissionRecord[]) ?? [];
@@ -258,20 +258,21 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
     const startedAtMs = new Date(s.startedAt).getTime();
 
     // Filter out submissions from before the current startedAt (e.g. after a reset)
-    const chronological = [...submissions]
-      .reverse()
-      .filter((sub) => new Date(sub.timestamp).getTime() >= startedAtMs);
+    const current = submissions.filter(
+      (sub) => new Date(sub.timestamp).getTime() >= startedAtMs,
+    );
 
-    for (const sub of chronological) {
+    let submissionIndex = 0;
+    for (const sub of current) {
+      submissionIndex++;
       for (const event of sub.auditEvents ?? []) {
-        const eventTime = new Date((event as AuditEvent).timestamp).getTime();
-        if (eventTime < startedAtMs) continue;
+        if (new Date(event.timestamp).getTime() < startedAtMs) continue;
         items.push({
           type: "audit",
-          timestamp: new Date((event as AuditEvent).timestamp),
-          verb: (event as AuditEvent).verb,
-          resource: (event as AuditEvent).resource,
-          name: (event as AuditEvent).name,
+          timestamp: new Date(event.timestamp),
+          verb: event.verb,
+          resource: event.resource,
+          name: event.name,
         });
       }
 
@@ -281,7 +282,8 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
         timestamp: new Date(sub.timestamp),
         validated: sub.validated,
         objectives: sub.objectives,
-        attemptNumber: sub.attemptNumber,
+        // Fall back to sequential index for old submissions without attemptNumber
+        attemptNumber: sub.attemptNumber ?? submissionIndex,
       });
     }
 
@@ -298,7 +300,10 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
       return TYPE_ORDER[a.type] - TYPE_ORDER[b.type];
     });
 
-    return items;
+    return {
+      items,
+      auditCount: items.filter((i) => i.type === "audit").length,
+    };
   }, [statusData, submissionsData, status]);
 
   if (
@@ -308,8 +313,6 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
   ) {
     return null;
   }
-
-  const auditCount = timelineItems.filter((i) => i.type === "audit").length;
 
   return (
     <Card className="neo-border-thick neo-shadow-xl bg-secondary mt-6">

--- a/apps/web/src/components/challenge-timeline.tsx
+++ b/apps/web/src/components/challenge-timeline.tsx
@@ -1,0 +1,350 @@
+import type { GetStatusOutput } from "@kubeasy/api-schemas/progress";
+import type {
+  AuditEvent,
+  Objective,
+  SubmissionRecord,
+} from "@kubeasy/api-schemas/submissions";
+import { Card, CardContent, CardHeader, CardTitle } from "@kubeasy/ui/card";
+import { useQuery } from "@tanstack/react-query";
+import type { InferResponseType } from "hono/client";
+import { CheckCircle2, Terminal, Trophy, XCircle } from "lucide-react";
+import { useMemo, useState } from "react";
+import { authClient } from "@/lib/auth-client";
+import {
+  challengeStatusOptions,
+  submissionsOptions,
+} from "@/lib/query-options";
+import type { rpc } from "@/lib/rpc";
+import { cn } from "@/lib/utils";
+
+type SubmissionsOutput = InferResponseType<
+  (typeof rpc.submissions)[":slug"]["$get"],
+  200
+>;
+
+type TimelineItem =
+  | { type: "start"; timestamp: Date }
+  | {
+      type: "audit";
+      timestamp: Date;
+      verb: string;
+      resource: string;
+      name?: string;
+    }
+  | {
+      type: "submission";
+      id: string;
+      timestamp: Date;
+      validated: boolean;
+      objectives: Objective[] | null;
+      attemptNumber: number;
+    }
+  | { type: "completed"; timestamp: Date };
+
+const TYPE_ORDER: Record<TimelineItem["type"], number> = {
+  start: 0,
+  audit: 1,
+  submission: 2,
+  completed: 3,
+};
+
+// Color-code audit events by verb for quick scanning
+const VERB_COLOR: Record<string, string> = {
+  create: "bg-green-500",
+  delete: "bg-red-500",
+  patch: "bg-blue-500",
+  update: "bg-amber-500",
+  apply: "bg-purple-500",
+  replace: "bg-orange-500",
+};
+
+function formatAuditEvent(item: Extract<TimelineItem, { type: "audit" }>) {
+  const target = item.name ? `${item.resource}/${item.name}` : item.resource;
+  return `${item.verb} ${target}`;
+}
+
+// Square spine markers — no circles in this design system
+function SpineMarker({ item }: { item: TimelineItem }) {
+  if (item.type === "start") {
+    return <div className="w-5 h-5 bg-black flex-shrink-0" />;
+  }
+  if (item.type === "completed") {
+    return <div className="w-5 h-5 bg-amber-400 neo-border flex-shrink-0" />;
+  }
+  if (item.type === "submission") {
+    return (
+      <div
+        className={cn(
+          "w-5 h-5 neo-border flex-shrink-0",
+          item.validated ? "bg-green-400" : "bg-red-400",
+        )}
+      />
+    );
+  }
+  // audit — verb-colored small square
+  const color = VERB_COLOR[item.verb] ?? "bg-black/30";
+  return <div className={cn("w-2.5 h-2.5 flex-shrink-0", color)} />;
+}
+
+function ObjectivesPopover({ objectives }: { objectives: Objective[] }) {
+  return (
+    <div className="absolute left-0 top-full mt-2 z-20 bg-white neo-border-thick neo-shadow p-4 min-w-64 max-w-sm">
+      <p className="text-xs font-black uppercase tracking-widest mb-3 text-black/40">
+        Objectives
+      </p>
+      <div className="space-y-2">
+        {objectives.map((obj) => (
+          <div key={obj.key} className="flex items-start gap-2.5">
+            {obj.passed ? (
+              <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0 mt-0.5" />
+            ) : (
+              <XCircle className="h-4 w-4 text-red-600 flex-shrink-0 mt-0.5" />
+            )}
+            <span className="text-sm font-bold leading-snug">{obj.title}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TimelineRow({
+  item,
+  isLast,
+}: {
+  item: TimelineItem;
+  isLast: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const isAudit = item.type === "audit";
+
+  return (
+    // relative mb-2: each row is its own block, spine is absolute behind
+    <div
+      className={cn(
+        "relative flex items-center gap-3",
+        isLast ? "" : isAudit ? "mb-1" : "mb-2",
+      )}
+    >
+      {/* Marker: z-10 sits on top of the absolute spine */}
+      <div className="w-8 flex-shrink-0 flex items-center justify-center z-10 relative">
+        <SpineMarker item={item} />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        {item.type === "start" && (
+          <div className="flex items-center justify-between neo-border-thick bg-black text-white px-4 py-2.5">
+            <span className="text-sm font-black uppercase tracking-widest">
+              Challenge Started
+            </span>
+            <span className="text-xs font-bold text-white/50 tabular-nums">
+              {item.timestamp.toLocaleTimeString()}
+            </span>
+          </div>
+        )}
+
+        {item.type === "audit" && (
+          <div className="flex items-center gap-3 neo-border bg-white px-3 py-1.5">
+            {/* Verb-colored accent square inside the row */}
+            <div
+              className={cn(
+                "w-1.5 h-4 flex-shrink-0",
+                VERB_COLOR[item.verb] ?? "bg-black/20",
+              )}
+            />
+            <span className="text-sm font-mono text-black/65 flex-1 truncate">
+              {formatAuditEvent(item)}
+            </span>
+            <span className="text-xs font-bold text-black/25 tabular-nums flex-shrink-0">
+              {item.timestamp.toLocaleTimeString()}
+            </span>
+          </div>
+        )}
+
+        {item.type === "submission" && (
+          <div
+            className="relative"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+          >
+            <div
+              className={cn(
+                "flex items-center justify-between px-4 py-2.5 neo-border-thick cursor-default transition-transform",
+                item.validated
+                  ? "bg-green-50 neo-border-green hover:translate-x-[2px] hover:translate-y-[2px]"
+                  : "bg-red-50 neo-border-destructive hover:translate-x-[2px] hover:translate-y-[2px]",
+              )}
+            >
+              <div className="flex items-center gap-2.5">
+                {item.validated ? (
+                  <CheckCircle2 className="h-5 w-5 text-green-700 flex-shrink-0" />
+                ) : (
+                  <XCircle className="h-5 w-5 text-red-700 flex-shrink-0" />
+                )}
+                <span
+                  className={cn(
+                    "text-sm font-black uppercase tracking-wide",
+                    item.validated ? "text-green-900" : "text-red-900",
+                  )}
+                >
+                  Submit #{item.attemptNumber}
+                </span>
+                <span
+                  className={cn(
+                    "text-sm font-bold",
+                    item.validated ? "text-green-700" : "text-red-700",
+                  )}
+                >
+                  — {item.validated ? "Passed" : "Failed"}
+                </span>
+              </div>
+              <span className="text-xs font-bold text-black/35 tabular-nums">
+                {item.timestamp.toLocaleTimeString()}
+              </span>
+            </div>
+            {hovered && item.objectives && item.objectives.length > 0 && (
+              <ObjectivesPopover objectives={item.objectives} />
+            )}
+          </div>
+        )}
+
+        {item.type === "completed" && (
+          <div className="flex items-center justify-between neo-border-thick bg-amber-50 neo-border-amber px-4 py-2.5">
+            <div className="flex items-center gap-2.5">
+              <Trophy className="h-5 w-5 text-amber-700 flex-shrink-0" />
+              <span className="text-sm font-black uppercase tracking-wide text-amber-900">
+                Challenge Complete
+              </span>
+            </div>
+            <span className="text-xs font-bold text-black/35 tabular-nums">
+              {item.timestamp.toLocaleTimeString()}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ChallengeTimeline({ slug }: { slug: string }) {
+  const { data: session } = authClient.useSession();
+  const isAuthenticated = !!session;
+
+  const { data: statusData } = useQuery({
+    ...challengeStatusOptions(slug),
+    enabled: isAuthenticated,
+  });
+
+  const { data: submissionsData } = useQuery({
+    ...submissionsOptions(slug),
+    enabled: isAuthenticated,
+  });
+
+  const status = statusData?.status ?? "not_started";
+
+  const timelineItems = useMemo((): TimelineItem[] => {
+    const s = statusData as GetStatusOutput | undefined;
+    if (!s?.startedAt) return [];
+
+    const items: TimelineItem[] = [];
+
+    items.push({ type: "start", timestamp: new Date(s.startedAt) });
+
+    const submissions =
+      ((submissionsData as SubmissionsOutput | undefined)
+        ?.submissions as SubmissionRecord[]) ?? [];
+
+    const startedAtMs = new Date(s.startedAt).getTime();
+
+    // Filter out submissions from before the current startedAt (e.g. after a reset)
+    const chronological = [...submissions]
+      .reverse()
+      .filter((sub) => new Date(sub.timestamp).getTime() >= startedAtMs);
+
+    for (const sub of chronological) {
+      for (const event of sub.auditEvents ?? []) {
+        const eventTime = new Date((event as AuditEvent).timestamp).getTime();
+        if (eventTime < startedAtMs) continue;
+        items.push({
+          type: "audit",
+          timestamp: new Date((event as AuditEvent).timestamp),
+          verb: (event as AuditEvent).verb,
+          resource: (event as AuditEvent).resource,
+          name: (event as AuditEvent).name,
+        });
+      }
+
+      items.push({
+        type: "submission",
+        id: sub.id,
+        timestamp: new Date(sub.timestamp),
+        validated: sub.validated,
+        objectives: sub.objectives,
+        attemptNumber: sub.attemptNumber,
+      });
+    }
+
+    if (status === "completed" && s.completedAt) {
+      items.push({
+        type: "completed",
+        timestamp: new Date(s.completedAt),
+      });
+    }
+
+    items.sort((a, b) => {
+      const timeDiff = a.timestamp.getTime() - b.timestamp.getTime();
+      if (timeDiff !== 0) return timeDiff;
+      return TYPE_ORDER[a.type] - TYPE_ORDER[b.type];
+    });
+
+    return items;
+  }, [statusData, submissionsData, status]);
+
+  if (
+    !isAuthenticated ||
+    status === "not_started" ||
+    timelineItems.length === 0
+  ) {
+    return null;
+  }
+
+  const auditCount = timelineItems.filter((i) => i.type === "audit").length;
+
+  return (
+    <Card className="neo-border-thick neo-shadow-xl bg-secondary mt-6">
+      <CardHeader>
+        <CardTitle className="text-2xl font-black flex items-center gap-3">
+          <Terminal className="h-6 w-6" />
+          Challenge History
+          {auditCount > 0 && (
+            <span className="ml-auto text-xs font-bold text-foreground/40 uppercase tracking-wide">
+              {auditCount} command{auditCount !== 1 ? "s" : ""}
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="relative">
+          {/* Continuous spine */}
+          <div className="absolute left-[15px] top-5 bottom-5 w-[3px] bg-black/20" />
+
+          {timelineItems.map((item, index) => {
+            const key =
+              item.type === "submission"
+                ? `submission-${item.id}`
+                : `${item.type}-${item.timestamp.toISOString()}-${index}`;
+
+            return (
+              <TimelineRow
+                key={key}
+                item={item}
+                isLast={index === timelineItems.length - 1}
+              />
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/challenge-timeline.tsx
+++ b/apps/web/src/components/challenge-timeline.tsx
@@ -253,6 +253,8 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
   const status = statusData?.status ?? "not_started";
 
   const { items: timelineItems, auditCount } = useMemo(() => {
+    // Hono client infers a discriminated union where { status: "not_started" } lacks
+    // startedAt, so s?.startedAt fails without this cast to the flat schema type.
     const s = statusData as GetStatusOutput | undefined;
     if (!s?.startedAt) return { items: [], auditCount: 0 };
 

--- a/apps/web/src/components/challenge-timeline.tsx
+++ b/apps/web/src/components/challenge-timeline.tsx
@@ -169,6 +169,7 @@ function TimelineRow({
             <div
               role="button"
               tabIndex={0}
+              aria-expanded={hovered && !!item.objectives?.length}
               className={cn(
                 "flex items-center justify-between px-4 py-2.5 neo-border-thick cursor-default transition-transform",
                 item.validated
@@ -178,6 +179,10 @@ function TimelineRow({
               onClick={() => setHovered((v) => !v)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") setHovered((v) => !v);
+              }}
+              onBlur={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node))
+                  setHovered(false);
               }}
             >
               <div className="flex items-center gap-2.5">
@@ -296,7 +301,7 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
       });
     }
 
-    if (status === "completed" && s.completedAt) {
+    if (s.status === "completed" && s.completedAt) {
       items.push({
         type: "completed",
         timestamp: new Date(s.completedAt),
@@ -313,7 +318,7 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
       items,
       auditCount: items.filter((i) => i.type === "audit").length,
     };
-  }, [statusData, submissionsData, status]);
+  }, [statusData, submissionsData]);
 
   // Returns null while loading (WEB-05: status/submissions are client-only queries).
   // The card appears after both queries resolve, which causes a one-time layout shift.

--- a/apps/web/src/components/challenge-timeline.tsx
+++ b/apps/web/src/components/challenge-timeline.tsx
@@ -167,12 +167,18 @@ function TimelineRow({
             onMouseLeave={() => setHovered(false)}
           >
             <div
+              role="button"
+              tabIndex={0}
               className={cn(
                 "flex items-center justify-between px-4 py-2.5 neo-border-thick cursor-default transition-transform",
                 item.validated
                   ? "bg-green-50 neo-border-green hover:translate-x-[2px] hover:translate-y-[2px]"
                   : "bg-red-50 neo-border-destructive hover:translate-x-[2px] hover:translate-y-[2px]",
               )}
+              onClick={() => setHovered((v) => !v)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") setHovered((v) => !v);
+              }}
             >
               <div className="flex items-center gap-2.5">
                 {item.validated ? (
@@ -261,6 +267,8 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
       (sub) => new Date(sub.timestamp).getTime() >= startedAtMs,
     );
 
+    // Each submission's auditEvents covers only that attempt window (non-cumulative).
+    // If the API ever returns cumulative events, this loop would produce duplicates.
     let submissionIndex = 0;
     for (const sub of current) {
       submissionIndex++;
@@ -307,6 +315,8 @@ export function ChallengeTimeline({ slug }: { slug: string }) {
     };
   }, [statusData, submissionsData, status]);
 
+  // Returns null while loading (WEB-05: status/submissions are client-only queries).
+  // The card appears after both queries resolve, which causes a one-time layout shift.
   if (
     !isAuthenticated ||
     status === "not_started" ||

--- a/apps/web/src/routes/challenges/$slug.tsx
+++ b/apps/web/src/routes/challenges/$slug.tsx
@@ -8,6 +8,7 @@ import type { RequestLogger } from "evlog";
 import { ArrowLeft, Clock } from "lucide-react";
 import { useRequest } from "nitro/context";
 import { ChallengeMission } from "@/components/challenge-mission";
+import { ChallengeTimeline } from "@/components/challenge-timeline";
 import { DifficultyBadge } from "@/components/difficulty-badge";
 import { siteConfig } from "@/lib/constants";
 import {
@@ -180,6 +181,7 @@ function ChallengeDetailPage() {
 
       {/* Challenge Mission with Real-time Validation Status */}
       <ChallengeMission slug={slug} />
+      <ChallengeTimeline slug={slug} />
     </div>
   );
 }

--- a/packages/api-schemas/src/submissions.ts
+++ b/packages/api-schemas/src/submissions.ts
@@ -97,7 +97,7 @@ export const SubmissionRecordSchema = z.object({
   validated: z.boolean(),
   objectives: z.array(ObjectiveSchema).nullable(),
   timestamp: z.string().describe("ISO 8601 date string"),
-  attemptNumber: z.number().int(),
+  attemptNumber: z.number().int().optional(),
   auditEvents: z.array(AuditEventSchema).nullable().optional(),
 });
 export type SubmissionRecord = z.infer<typeof SubmissionRecordSchema>;

--- a/packages/api-schemas/src/submissions.ts
+++ b/packages/api-schemas/src/submissions.ts
@@ -97,5 +97,7 @@ export const SubmissionRecordSchema = z.object({
   validated: z.boolean(),
   objectives: z.array(ObjectiveSchema).nullable(),
   timestamp: z.string().describe("ISO 8601 date string"),
+  attemptNumber: z.number().int(),
+  auditEvents: z.array(AuditEventSchema).nullable().optional(),
 });
 export type SubmissionRecord = z.infer<typeof SubmissionRecordSchema>;


### PR DESCRIPTION
## Summary

- Adds a `ChallengeTimeline` card below `ChallengeMission` on the challenge detail page, showing a chronological frise of the current session
- Timeline includes: started marker, kubectl audit events (verb-colored accents for `create`/`delete`/`patch`/`update`), submission markers with hover-to-show-objectives popover, and a completion marker
- Events and submissions predating the current `startedAt` (e.g. from before a challenge reset) are filtered out
- Removes the "View History" dialog from `ChallengeMission` — the timeline supersedes it
- Extends `SubmissionRecordSchema` with `attemptNumber` and `auditEvents` fields (nullable/optional for backward compat with old submissions)

## Test plan

- [ ] Start a challenge, run some kubectl commands, submit — verify timeline shows started marker, audit events, and submission row
- [ ] Hover over a submission row — verify objectives popover appears
- [ ] Reset a challenge and start again — verify old submissions/events are filtered out of the timeline
- [ ] Challenge with no audit events (old submission) — verify it renders without crashing
- [ ] Completed challenge — verify "Challenge Complete" amber marker appears at the bottom
- [ ] Not logged in — verify timeline is not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)