### PR TITLE
fix(api): validate slug format in submit route

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -672,7 +672,9 @@
             "in": "path",
             "name": "slug",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 200,
+              "pattern": "^[a-z0-9-]+$"
             },
             "required": true
           }
@@ -1917,7 +1919,9 @@
             "in": "path",
             "name": "slug",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 200,
+              "pattern": "^[a-z0-9-]+$"
             },
             "required": true
           }

--- a/apps/api/src/routes/submit.ts
+++ b/apps/api/src/routes/submit.ts
@@ -30,7 +30,12 @@ const challengeSubmissionQueue = createQueue(
   redis.options,
 );
 
-const slugParam = z.object({ slug: z.string() });
+const slugParam = z.object({
+  slug: z
+    .string()
+    .max(200)
+    .regex(/^[a-z0-9-]+$/, "Invalid slug format"),
+});
 
 const submitRateLimit = slidingWindowRateLimit(redis, {
   windowMs: 10_000,


### PR DESCRIPTION
## Summary

- Bring `POST /api/challenges/:slug/submit` slug validation in line with `progress.ts` by adding `.max(200).regex(/^[a-z0-9-]+$/)` to the route's Zod `slugParam`.
- The slug flows into BullMQ `jobId`s and Redis pub/sub channels, where `*` and `?` are meaningful glob wildcards — accepting an unconstrained string is a real injection surface.

Closes #173

## Test plan

- [x] `pnpm typecheck` passes (turbo run across all 7 packages — green)
- [ ] CI runs the existing api test suite (including `__tests__/submit.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)