### PR TITLE
perf(api): eliminate redundant XP query in GET /user/xp

### DIFF
--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -21,7 +21,7 @@ import {
   sessionSecurity,
 } from "../lib/openapi-shared";
 import { type AppEnv, requireAuth } from "../middleware/session";
-import { calculateLevel, calculateStreak } from "../services/xp/index";
+import { calculateStreak, getRankFromXp } from "../services/xp/index";
 
 const updateNameSchema = z.object({
   firstName: z.string().min(1),
@@ -121,7 +121,7 @@ export const userRouter = new Hono<AppEnv>()
             .where(eq(userXpTransaction.userId, userId));
 
           const xpEarned = result[0]?.totalXp ?? 0;
-          const rankInfo = await calculateLevel(userId);
+          const rankInfo = getRankFromXp(xpEarned);
 
           return { xpEarned, rank: rankInfo.name, rankInfo };
         },

--- a/apps/api/src/services/xp/calculateLevel.ts
+++ b/apps/api/src/services/xp/calculateLevel.ts
@@ -1,6 +1,3 @@
-import { eq, sql } from "drizzle-orm";
-import { db } from "../../db/index";
-import { userXpTransaction } from "../../db/schema/index";
 import { RANK_THRESHOLDS } from "./constants";
 import type { RankInfo } from "./types";
 
@@ -36,15 +33,4 @@ export function getRankFromXp(totalXp: number): RankInfo {
     nextRankXp,
     progress,
   };
-}
-
-export async function calculateLevel(userId: string): Promise<RankInfo> {
-  const result = await db
-    .select({
-      totalXp: sql<number>`COALESCE(SUM(${userXpTransaction.xpAmount}), 0)`,
-    })
-    .from(userXpTransaction)
-    .where(eq(userXpTransaction.userId, userId));
-
-  return getRankFromXp(result[0]?.totalXp ?? 0);
 }

--- a/apps/api/src/services/xp/index.ts
+++ b/apps/api/src/services/xp/index.ts
@@ -9,7 +9,7 @@
  * All functions are tested with comprehensive test coverage
  */
 
-export { calculateLevel, getRankFromXp } from "./calculateLevel";
+export { getRankFromXp } from "./calculateLevel";
 // Core functions
 export { calculateStreak } from "./calculateStreak";
 export { calculateXPGain } from "./calculateXPGain";


### PR DESCRIPTION
## Summary

`GET /user/xp` executed **two identical** `COALESCE(SUM(xpAmount))` queries on `user_xp_transaction` for the same user, sequentially, on every cache miss:

1. Once inline in the route to compute `xpEarned`.
2. Again inside `calculateLevel(userId)`, which re-ran the exact same query before delegating to the pure `getRankFromXp()` helper.

This implements **Option B** from #160: the route now reuses the already-fetched total via the existing pure `getRankFromXp(xpEarned)` helper, eliminating the second query entirely. The now-unused `calculateLevel()` function (its only caller) is removed, along with its dead DB imports.

The response shape is unchanged (`{ xpEarned, rank, rankInfo }`), so no OpenAPI regeneration is needed.

## Changes

- `apps/api/src/routes/user.ts` — call `getRankFromXp(xpEarned)` instead of `await calculateLevel(userId)`.
- `apps/api/src/services/xp/calculateLevel.ts` — remove the dead `calculateLevel()` function and its now-unused `db`/drizzle imports.
- `apps/api/src/services/xp/index.ts` — drop the `calculateLevel` re-export.

## Test plan

- [x] `pnpm typecheck` passes (full monorepo, via pre-commit hook)
- [x] `pnpm --filter @kubeasy/api test:run` passes
- [x] No remaining references to `calculateLevel`

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)